### PR TITLE
feat: 补充多环境安装文档与一键安装脚本

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,69 @@ Job Copilot 更关注的是：
 
 目标不是让简历“看起来强”，而是让候选人“真的能讲住这份强简历”。
 
+## Installation / 安装
+
+### 1. Prompt 安装
+
+一句话直接让当前 AI 帮你安装：
+
+```text
+请把 https://github.com/InRainbowsX/job-copilot-skill 安装为当前环境可用的 skill，目录名使用 job-copilot-skill，如果已安装则更新，并在完成后告诉我如何调用它。
+```
+
+### 2. 一键脚本安装
+
+默认自动识别当前环境，优先安装到 Claude Code、Codex 或 OpenClaw 的标准 skills 目录。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/InRainbowsX/job-copilot-skill/main/install.sh | bash
+```
+
+也可以显式指定环境：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/InRainbowsX/job-copilot-skill/main/install.sh | bash -s -- claude
+curl -fsSL https://raw.githubusercontent.com/InRainbowsX/job-copilot-skill/main/install.sh | bash -s -- codex
+curl -fsSL https://raw.githubusercontent.com/InRainbowsX/job-copilot-skill/main/install.sh | bash -s -- openclaw
+```
+
+对应安装目录：
+
+- `Claude Code`: `~/.claude/skills/job-copilot-skill`
+- `Codex`: `~/.codex/skills/job-copilot-skill`
+- `OpenClaw`: `~/.openclaw/skills/job-copilot-skill`
+
+### 3. 手动 clone 安装
+
+如果你更希望手动管理 skill，可以直接 clone 到目标目录。
+
+Claude Code:
+
+```bash
+mkdir -p ~/.claude/skills
+git clone https://github.com/InRainbowsX/job-copilot-skill.git ~/.claude/skills/job-copilot-skill
+```
+
+Codex:
+
+```bash
+mkdir -p ~/.codex/skills
+git clone https://github.com/InRainbowsX/job-copilot-skill.git ~/.codex/skills/job-copilot-skill
+```
+
+OpenClaw:
+
+```bash
+mkdir -p ~/.openclaw/skills
+git clone https://github.com/InRainbowsX/job-copilot-skill.git ~/.openclaw/skills/job-copilot-skill
+```
+
+安装完成后，推荐用这句话开始：
+
+```text
+使用 $job-copilot-skill，基于我的原始简历和自我介绍，识别岗位方向并开始深挖项目。
+```
+
 ## 仓库结构
 
 ```text

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Job Copilot"
-  short_description: "Resume packaging and interview coaching"
+  short_description: "互联网求职简历包装、项目深挖与模拟面试教练"
   default_prompt: "Use $job-copilot-skill to deepen my projects, optimize my resume, and coach me through interview prep."

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_URL="https://github.com/InRainbowsX/job-copilot-skill.git"
+SKILL_NAME="job-copilot-skill"
+TARGET_ENV="${1:-auto}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash install.sh [claude|codex|openclaw|auto]
+
+Examples:
+  bash install.sh
+  bash install.sh codex
+EOF
+}
+
+detect_env() {
+  if [[ -d "$HOME/.claude" ]]; then
+    echo "claude"
+    return
+  fi
+
+  if [[ -d "$HOME/.codex" ]]; then
+    echo "codex"
+    return
+  fi
+
+  if [[ -d "$HOME/.openclaw" ]]; then
+    echo "openclaw"
+    return
+  fi
+
+  echo "codex"
+}
+
+resolve_target_dir() {
+  case "$1" in
+    claude)
+      echo "$HOME/.claude/skills/$SKILL_NAME"
+      ;;
+    codex)
+      echo "$HOME/.codex/skills/$SKILL_NAME"
+      ;;
+    openclaw)
+      echo "$HOME/.openclaw/skills/$SKILL_NAME"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
+if [[ "$TARGET_ENV" == "--help" || "$TARGET_ENV" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$TARGET_ENV" == "auto" ]]; then
+  TARGET_ENV="$(detect_env)"
+fi
+
+TARGET_DIR="$(resolve_target_dir "$TARGET_ENV")"
+
+if [[ -z "$TARGET_DIR" ]]; then
+  echo "Unsupported target: $TARGET_ENV" >&2
+  usage >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$TARGET_DIR")"
+
+if [[ -d "$TARGET_DIR/.git" ]]; then
+  echo "Updating $SKILL_NAME in $TARGET_DIR"
+  git -C "$TARGET_DIR" pull --ff-only
+else
+  if [[ -e "$TARGET_DIR" ]]; then
+    echo "Target exists but is not a git repository: $TARGET_DIR" >&2
+    exit 1
+  fi
+
+  echo "Installing $SKILL_NAME to $TARGET_DIR"
+  git clone "$REPO_URL" "$TARGET_DIR"
+fi
+
+if [[ ! -f "$TARGET_DIR/SKILL.md" ]]; then
+  echo "Installation failed: SKILL.md not found in $TARGET_DIR" >&2
+  exit 1
+fi
+
+echo
+echo "Installed successfully."
+echo "Environment: $TARGET_ENV"
+echo "Path: $TARGET_DIR"
+echo
+echo "Suggested invocation:"
+echo "使用 \$job-copilot-skill，基于我的原始简历和自我介绍，识别岗位方向并开始深挖项目。"


### PR DESCRIPTION
## 变更摘要

- 改了什么：在 README 中补充 Prompt 安装、一键脚本安装、手动 clone 安装三种方式，并新增 `install.sh`
- 为什么改：降低 skill 的安装门槛，覆盖 Claude Code、Codex、OpenClaw 三种环境

## 关联 Issue

close #8

- [x] 本 PR 在开始实现前已经有对应 Issue
- [x] 对应 Issue 已包含背景、要做什么、别做什么、什么算完成
- [x] 本 PR 标题或正文已明确关联 Issue

## 影响层级

- [ ] SKILL.md
- [ ] references
- [ ] assets
- [x] README
- [x] governance

## 验证情况

- [x] 已运行 `./scripts/run_checks.sh`
- [ ] 行为变更时已更新验证场景
- [x] 已评估包装风险影响
- [x] 已检查本次改动没有脱离 Issue 约定范围

补充验证：
- [x] `bash install.sh --help`
- [x] 在临时 HOME 下实际执行 `bash install.sh codex` 并确认 `SKILL.md` 安装成功

## 风险说明

- 新风险：`install.sh` 的自动环境识别可能在极少数本地目录布局下不够精确
- 缓解方式：支持显式传入 `claude` / `codex` / `openclaw`，README 中已给出明确用法