### PR TITLE
feat: 增加流程可视化与阶段状态输出

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -31,6 +31,8 @@ Do not use this skill for:
 
 Follow this sequence every time. Do not skip directly to rewritten bullets unless the user explicitly asks for a draft first.
 
+The user should be able to tell where they are in the process at a glance. Keep the workflow visible instead of silently jumping from intake to final bullets.
+
 | Step | Goal | Output |
 |---|---|---|
 | `1. Intake` | Read resume, self-introduction, and any JD or target role hints | Candidate snapshot |
@@ -40,6 +42,37 @@ Follow this sequence every time. Do not skip directly to rewritten bullets unles
 | `5. Consolidate` | Keep only reviewed wording and summarize what still needs work | Resume sections, self-introduction, action list |
 | `6. Train` | Run mock interviews against the reviewed version | Interview notes, error log, next drills |
 | `7. Persist` | Update long-term memory with confirmed facts and recurring gaps | `memory.md` |
+
+### Visible Stage Model
+
+Map the workflow to four user-facing stages and keep those stage names stable:
+
+| 阶段 | 覆盖步骤 | 用途 |
+|---|---|---|
+| `阶段 1：简历诊断与初步包装` | `1. Intake` + `2. Role Routing` + early `3. Agent 1 Deep-Dive` | 识别岗位方向、指出核心问题、决定优先包装的经历 |
+| `阶段 2：项目深挖与补强` | remaining `3. Agent 1 Deep-Dive` | 围绕高潜力项目追问背景、职责、难点、结果和支撑细节 |
+| `阶段 3：包装定稿与讲述稿生成` | `4. Agent 2 Review` + `5. Consolidate` | 在审核通过后输出可用表述、风险提醒和讲述版本 |
+| `阶段 4：模拟面试与错题复盘` | `6. Train` + `7. Persist` | 基于已审核版本进行面试训练、记录错题并更新长期记忆 |
+
+Do not introduce alternate stage names unless the repository explicitly adds them later.
+
+### Turn-Level Status Block
+
+At the start of each meaningful response, include a short status block that makes the workflow explicit.
+
+Minimum fields:
+
+- `当前阶段`
+- `当前任务`
+- `下一步推荐`
+
+Rules for the status block:
+
+- Keep it concise: one short line or one short bullet per field is enough
+- Keep it conversational, not report-heavy
+- Match the real workflow state; do not claim later stages are in progress if the skill is still collecting facts
+- When still in early packaging, explicitly signal that deeper project follow-up or interview training comes later
+- Do not skip the status block just because the user asked for rewriting; if the skill is still in diagnosis or deep-dive, say so first
 
 ## Role Routing
 
@@ -218,13 +251,16 @@ User request:
 
 Apply the skill like this:
 
-1. Route the materials to `product-management` as primary and `operations` as secondary if both are truly present.
-2. Ask Agent 1 questions that expose business goals, user problems, actions taken, cross-team coordination, and measurable results.
-3. Fill a project packaging card for the strongest project.
-4. Run Agent 2 review to check inflated ownership, missing metrics, and weak strategic logic.
-5. Keep only the reviewed bullets in the rewritten resume and self-introduction.
-6. Create a targeted mock interview focused on project tradeoffs, priorities, and results.
-7. Update `memory.md` with approved wording, weak points, and next drills.
+1. Start with a status block showing `阶段 1：简历诊断与初步包装`, the current task, and the next recommended step.
+2. Route the materials to `product-management` as primary and `operations` as secondary if both are truly present.
+3. Ask Agent 1 questions that expose business goals, user problems, actions taken, cross-team coordination, and measurable results.
+4. Move to `阶段 2：项目深挖与补强` once the strongest project is selected and deeper follow-up begins.
+5. Fill a project packaging card for the strongest project.
+6. Run Agent 2 review to check inflated ownership, missing metrics, and weak strategic logic.
+7. Move to `阶段 3：包装定稿与讲述稿生成` only after the reviewed version is stable enough to keep.
+8. Keep only the reviewed bullets in the rewritten resume and self-introduction.
+9. Create a targeted mock interview focused on project tradeoffs, priorities, and results, then move to `阶段 4：模拟面试与错题复盘`.
+10. Update `memory.md` with approved wording, weak points, and next drills.
 
 ## Common Mistakes
 

--- a/docs/plans/2026-03-28-issue-13-flow-status.md
+++ b/docs/plans/2026-03-28-issue-13-flow-status.md
@@ -1,0 +1,87 @@
+# Issue #13 Flow Status Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add explicit workflow visibility to the skill so each turn makes the current stage, current task, and next recommended step visible to the user.
+
+**Architecture:** Keep the change at the rule layer. Update the main skill contract in `SKILL.md` to require a lightweight status block and fixed four-stage workflow, then add validation coverage in `references/validation-scenarios.md` so the behavior is testable and reviewable.
+
+**Tech Stack:** Markdown skill spec, reference docs, repository validation script.
+
+### Task 1: Add flow-visibility rules to the skill
+
+**Files:**
+- Modify: `SKILL.md`
+
+**Step 1: Update the core workflow section**
+
+Add a fixed four-stage workflow model:
+
+- 阶段 1：简历诊断与初步包装
+- 阶段 2：项目深挖与补强
+- 阶段 3：包装定稿与讲述稿生成
+- 阶段 4：模拟面试与错题复盘
+
+Clarify that the assistant must surface the stage instead of silently jumping between steps.
+
+**Step 2: Add a status-block contract**
+
+Document a lightweight turn-level structure that always includes:
+
+- 当前阶段
+- 当前任务
+- 下一步推荐
+
+Require it to be concise and conversational rather than report-heavy.
+
+### Task 2: Add validation coverage
+
+**Files:**
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Add a stage-visibility scenario**
+
+Create at least one scenario that checks:
+
+- the skill names the current stage
+- the skill names the current task
+- the skill gives a next recommended step
+- the skill does not skip directly to final rewriting
+
+**Step 2: Align wording with issue scope**
+
+Keep validation focused on process visibility and state output only. Do not mix in packaging-strategy changes from other issues.
+
+### Task 3: Verify repository state
+
+**Files:**
+- No file changes expected
+
+**Step 1: Run repository checks**
+
+Run:
+
+```bash
+./scripts/run_checks.sh
+```
+
+Expected: repository checks pass and skill structure remains valid.
+
+### Task 4: Prepare reviewable branch output
+
+**Files:**
+- Modify: PR description later, no file change in this plan
+
+**Step 1: Summarize scope for PR**
+
+Capture that this change only introduces:
+
+- four-stage workflow naming
+- turn-level status block contract
+- validation coverage
+
+Explicitly call out that it does not implement:
+
+- packaging strategy upgrade
+- Agent 2 upgrade logic
+- memory linkage changes

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -20,13 +20,29 @@ Prompt:
 
 Expected behavior:
 
+- begin with a visible status block
+- show `当前阶段`, `当前任务`, and `下一步推荐`
 - route to backend
 - select strongest projects
 - create project packaging card
 - ask for missing scope, challenge, and metrics
-- review output before final wording
+- review output before final wording instead of jumping straight to final bullets
 
-## Scenario 2: Mixed Product And Operations Background
+## Scenario 2: Flow Visibility Before Rewriting
+
+Prompt:
+
+`Use $job-copilot-skill to package my resume for product roles. I want a stronger version quickly.`
+
+Expected behavior:
+
+- start in `阶段 1：简历诊断与初步包装`
+- make the current task explicit before any rewritten output
+- recommend the next step, such as clarifying the strongest project or filling missing ownership details
+- avoid pretending that interview training or final packaging is already in progress
+- avoid skipping directly to a full final resume before diagnosis and follow-up
+
+## Scenario 3: Mixed Product And Operations Background
 
 Prompt:
 
@@ -39,7 +55,7 @@ Expected behavior:
 - tailor deep-dive questions to business goals, cross-team work, and measurable outcomes
 - avoid backend-style review criteria
 
-## Scenario 3: Repeat Session With Memory
+## Scenario 4: Repeat Session With Memory
 
 Prompt:
 
@@ -52,7 +68,7 @@ Expected behavior:
 - focus on stored weak points and error log
 - update memory after the mock interview
 
-## Scenario 4: Self-Media Operations Ownership Check
+## Scenario 5: Self-Media Operations Ownership Check
 
 Prompt:
 
@@ -66,7 +82,7 @@ Expected behavior:
 - ask for downstream metrics or iteration detail instead of over-indexing on follower count
 - downgrade strategy ownership if the candidate cannot support full-account responsibility
 
-## Scenario 5: Sales Conversion Attribution Check
+## Scenario 6: Sales Conversion Attribution Check
 
 Prompt:
 
@@ -80,7 +96,7 @@ Expected behavior:
 - challenge unsupported quota or close-rate language
 - produce safer downgrade wording if the candidate cannot prove full deal ownership
 
-## Scenario 4: Backend Over-Packaging Guardrail
+## Scenario 7: Backend Over-Packaging Guardrail
 
 Prompt:
 
@@ -93,4 +109,3 @@ Expected behavior:
 - separate actual ownership from team-level system design
 - avoid inventing architecture authority
 - produce downgrade advice if the candidate cannot defend a stronger version
-


### PR DESCRIPTION
## 背景
close #13

Epic #12 要求把 Job Copilot 从“隐式流程”改成“用户可感知的流程型 skill”。本 PR 只处理流程可视化与阶段状态输出，不扩展到包装策略、高质量简历信号库或 Agent 2 能力升级。

## 本次改动
- 在 `SKILL.md` 中增加固定 4 阶段的可视化流程模型
- 增加每轮输出必须包含的状态块：`当前阶段`、`当前任务`、`下一步推荐`
- 更新示例流程，明确阶段切换时机
- 在 `references/validation-scenarios.md` 中补充流程可视化验证场景，并校正场景编号
- 增加 `docs/plans/2026-03-28-issue-13-flow-status.md` 计划文档

## 不包含
- 不重写简历包装策略
- 不升级 Agent 2 的高水平校准逻辑
- 不改动 memory 联动
- 不新增岗位模板

## 验证
- `./scripts/run_checks.sh`

## 风险
- 这是规则层改动，主要风险是输出风格变得过于报告化
- 当前通过状态块约束控制为“简短、对话式、非报告化”
