### PR TITLE
feat: 将流程状态块升级为强制开场格式

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -58,7 +58,15 @@ Do not introduce alternate stage names unless the repository explicitly adds the
 
 ### Turn-Level Status Block
 
+The status block is required, not optional.
+
 At the start of each meaningful response, include a short status block that makes the workflow explicit.
+
+You must begin the response with this status block in all of these cases:
+
+- the first meaningful response after the user provides a resume, self-introduction, or target role
+- any response that moves the workflow into a new stage
+- any response where the user asks for rewriting but the skill still needs diagnosis, routing, or follow-up questions
 
 Minimum fields:
 
@@ -70,9 +78,11 @@ Rules for the status block:
 
 - Keep it concise: one short line or one short bullet per field is enough
 - Keep it conversational, not report-heavy
+- Put it before deeper analysis or rewritten content
 - Match the real workflow state; do not claim later stages are in progress if the skill is still collecting facts
 - When still in early packaging, explicitly signal that deeper project follow-up or interview training comes later
-- Do not skip the status block just because the user asked for rewriting; if the skill is still in diagnosis or deep-dive, say so first
+- Do not skip it just because the user asked for a faster result
+- If the skill is still in diagnosis or deep-dive, say so first rather than acting as if final packaging is already underway
 
 ## Role Routing
 

--- a/docs/plans/2026-03-28-issue-26-force-status-block.md
+++ b/docs/plans/2026-03-28-issue-26-force-status-block.md
@@ -1,0 +1,83 @@
+# Issue #26 Force Status Block Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the workflow status block a mandatory opening structure for the first turn and for key transition turns so users can reliably see the current stage, current task, and next recommended step.
+
+**Architecture:** Keep the change at the rule layer and validation layer. Update `SKILL.md` so the status block is no longer a soft suggestion but a required opening contract, then extend `references/validation-scenarios.md` to check for missing status blocks in realistic resume-packaging prompts.
+
+**Tech Stack:** Markdown skill spec, validation reference docs, repository validation script.
+
+### Task 1: Tighten the status-block rule in `SKILL.md`
+
+**Files:**
+- Modify: `SKILL.md`
+
+**Step 1: Add fixed workflow visibility rules**
+
+Document that the skill must surface a concise status block:
+
+- on the first response after resume intake
+- when the workflow moves into a new stage
+- when the user explicitly asks for rewriting but the skill still needs diagnosis or follow-up
+
+**Step 2: Define the minimum format**
+
+Require the first lines of the response to show:
+
+- `当前阶段`
+- `当前任务`
+- `下一步推荐`
+
+Clarify that the block should remain short and conversational.
+
+### Task 2: Add validation coverage
+
+**Files:**
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Add scenario coverage for missing status blocks**
+
+Add or update scenarios so the validation explicitly fails if:
+
+- the response starts rewriting without a status block
+- the response jumps to a later stage without saying so
+- the response omits `当前阶段 / 当前任务 / 下一步推荐`
+
+**Step 2: Keep scope narrow**
+
+Do not fold in packaging-strategy, timeline, or gap-handling behavior here.
+
+### Task 3: Verify repository health
+
+**Files:**
+- No file changes expected
+
+**Step 1: Run repository checks**
+
+Run:
+
+```bash
+./scripts/run_checks.sh
+```
+
+Expected: repository checks pass.
+
+### Task 4: Prepare PR scope
+
+**Files:**
+- No file changes expected
+
+**Step 1: Keep PR scope explicit**
+
+The PR should clearly state that it only does:
+
+- mandatory status-block opening rules
+- stage-transition visibility rules
+- validation updates
+
+It should explicitly not claim to implement:
+
+- packaging redesign
+- timeline weighting
+- gap packaging

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -42,7 +42,21 @@ Expected behavior:
 - avoid pretending that interview training or final packaging is already in progress
 - avoid skipping directly to a full final resume before diagnosis and follow-up
 
-## Scenario 3: Mixed Product And Operations Background
+## Scenario 3: Force Status Block Before Fast Rewrite
+
+Prompt:
+
+`Use $job-copilot-skill to rewrite my resume quickly for product roles. Give me a strong version directly.`
+
+Expected behavior:
+
+- still begin with a status block
+- still make the current stage explicit
+- state the current task before giving any rewritten content
+- recommend the next step if diagnosis or follow-up is still needed
+- avoid pretending the flow is already in final packaging or mock interview mode
+
+## Scenario 4: Mixed Product And Operations Background
 
 Prompt:
 
@@ -55,7 +69,7 @@ Expected behavior:
 - tailor deep-dive questions to business goals, cross-team work, and measurable outcomes
 - avoid backend-style review criteria
 
-## Scenario 4: Repeat Session With Memory
+## Scenario 5: Repeat Session With Memory
 
 Prompt:
 
@@ -68,7 +82,7 @@ Expected behavior:
 - focus on stored weak points and error log
 - update memory after the mock interview
 
-## Scenario 5: Self-Media Operations Ownership Check
+## Scenario 6: Self-Media Operations Ownership Check
 
 Prompt:
 
@@ -82,7 +96,7 @@ Expected behavior:
 - ask for downstream metrics or iteration detail instead of over-indexing on follower count
 - downgrade strategy ownership if the candidate cannot support full-account responsibility
 
-## Scenario 6: Sales Conversion Attribution Check
+## Scenario 7: Sales Conversion Attribution Check
 
 Prompt:
 
@@ -96,7 +110,7 @@ Expected behavior:
 - challenge unsupported quota or close-rate language
 - produce safer downgrade wording if the candidate cannot prove full deal ownership
 
-## Scenario 7: Backend Over-Packaging Guardrail
+## Scenario 8: Backend Over-Packaging Guardrail
 
 Prompt:
 


### PR DESCRIPTION
## 背景
close #26

用户已经在真实验证中确认，当前状态块规则并没有稳定生效。这个 PR 只处理“状态块必须强制开场”这一件事，不扩展到时间轴、Gap 或包装策略本身。

## 本次改动
- 在 `SKILL.md` 中增加固定四阶段的可见阶段模型
- 将状态块从软规则升级为强制开场规则
- 明确状态块必须出现的场景：首轮、阶段切换、用户要求直接改写但仍需诊断时
- 明确状态块最小字段：`当前阶段`、`当前任务`、`下一步推荐`
- 在 `references/validation-scenarios.md` 中增加“快速改写也必须先显示状态块”的验证场景
- 增加 `docs/plans/2026-03-28-issue-26-force-status-block.md` 计划文档

## 不包含
- 不处理时间轴优先级
- 不处理 Gap 期识别与包装
- 不处理简历包装教练或审核官的能力升级
- 不处理 memory 联动

## 验证
- `./scripts/run_checks.sh`

## 风险
- 主要风险是状态块过重，影响对话自然度
- 当前通过“短行、对话式、先状态后内容”的规则约束控制风险
