### PR TITLE
feat: 增加时间轴优先级与最近经历加权规则

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -94,6 +94,9 @@ Evaluate experience on a timeline before locking the main narrative. Do not choo
 
 Default weighting rules:
 
+- Anchor the timeline analysis to the current session date, not to a vague sense of "recent" or "too far"
+- If the current date is known, state it explicitly in the analysis before judging which experience should carry the main narrative
+- Compare actual experience time ranges against the current date whenever the timeline materially affects the conclusion
 - In social-hire contexts, prioritize recent 1 to 3 year experience first
 - Recent experience should normally outrank distant campus experience when both can support the target role
 - Role relevance still matters; recent but irrelevant experience should not automatically beat weaker but clearly relevant experience
@@ -113,9 +116,13 @@ Downgrade campus experience to supporting evidence when:
 
 When timeline weighting affects the result, make it explicit in the analysis:
 
+- what current date or hiring moment the analysis is using
+- what the relevant time ranges are for the newer work and the older experience
 - which experience is the current main narrative
 - which older experience is retained as supporting evidence
 - why the older experience was downgraded or kept
+
+If the case is borderline, do not just say an older experience is "too far" or "still usable." Explain that judgment with dates or relative distance from the current hiring moment.
 
 Supported template families:
 

--- a/docs/plans/2026-03-28-issue-23-timeline-weighting.md
+++ b/docs/plans/2026-03-28-issue-23-timeline-weighting.md
@@ -17,6 +17,8 @@
 
 Document that, by default:
 
+- the current session date or current hiring moment should be stated when timeline weighting matters
+- the analysis should compare concrete experience time ranges, not just say "recent" or "too far"
 - recent 1 to 3 year experience carries the highest weight
 - timeline priority applies before choosing the main project narrative
 - role relevance still matters, but distant experience should not automatically outrank recent work just because it sounds stronger
@@ -42,6 +44,7 @@ Clarify when campus experience should be downgraded:
 
 Create a scenario where:
 
+- the current date is explicit
 - the candidate has an older campus content project
 - the candidate also has newer work experience
 - the skill should keep the newer work as the main narrative unless the newer work clearly fails the target role

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -128,12 +128,15 @@ Expected behavior:
 
 Prompt:
 
-`Use $job-copilot-skill to help me target content operations roles. I have a strong campus self-media project from several years ago, but I also have more recent store and advertising operations work.`
+`Today is 2026-03-29. Use $job-copilot-skill to help me target content operations roles. I have a strong campus self-media project from 2021, but I also have store operations work from 2024 and advertising operations work from 2025.`
 
 Expected behavior:
 
 - recognize the case as a social-hire timeline, not a campus-first timeline
+- explicitly anchor the judgment to the current date or current hiring moment
+- compare the 2021 campus experience against the 2024-2025 work experience instead of using vague language
 - evaluate recent 1 to 3 year experience before choosing the main narrative
 - avoid automatically making the older campus project the main story just because it sounds stronger
 - keep the campus project only as the main narrative if the newer work is clearly too weak or too unrelated
 - explain which experience is the current main narrative and which is supporting evidence
+- explain why the 2021 experience is downgraded or kept at the 2026-03-29 time point


### PR DESCRIPTION
## 背景
close #23

当前简历分析容易按“哪段更亮”来选主项目，忽略了社招场景里最近经历的时间权重。这个 PR 只处理时间轴优先级与最近经历加权，不扩展到 Gap 期和非标准经历包装。

## 本次改动
- 在 `SKILL.md` 中增加 `Timeline Priority` 规则
- 明确社招默认优先评估最近 1 到 3 年经历
- 明确远期校园经历何时可以升为主项目、何时应降为补充亮点
- 补充要求：时间轴分析必须锚定当前日期或当前招聘时点，不能只用模糊的“太远”或“最近”描述
- 补充要求：当时间轴影响结论时，需要明确写出较新经历与旧经历的时间区间，以及降权或保留原因
- 在 `references/validation-scenarios.md` 中增加并强化“远期校园经历不应压过最近工作经历”的验证场景
- 增加 `docs/plans/2026-03-28-issue-23-timeline-weighting.md` 计划文档

## 不包含
- 不处理 Gap 期识别
- 不处理 Gap 期包装与面试解释
- 不处理简历包装教练或审核官能力升级
- 不处理 memory 字段扩展

## 验证
- `./scripts/run_checks.sh`
- 按规则用例复测 `Recent Experience Outranks Distant Campus Experience`
  - 检查是否要求显式当前日期
  - 检查是否要求对比具体经历时间段
  - 检查是否要求说明旧经历在当前时间点为何被降权或保留

## 风险
- 主要风险是把“最近经历优先”写成机械规则
- 当前通过“最近经历优先 + 岗位相关性约束 + 校园经历升降权条件 + 显式日期/时间段解释”控制这个风险
