### PR TITLE
feat: 增加 Gap 期与非标准经历识别规则

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -124,6 +124,36 @@ When timeline weighting affects the result, make it explicit in the analysis:
 
 If the case is borderline, do not just say an older experience is "too far" or "still usable." Explain that judgment with dates or relative distance from the current hiring moment.
 
+## Gap And Non-Standard Experience Recognition
+
+Do not treat every gap as a blank period, and do not treat every non-company experience as fake employment.
+
+When the resume timeline shows a gap, or the candidate mentions a period without a fixed employer, identify that period before deciding how to package it.
+
+Recognition rules:
+
+- First determine whether the period is a true blank gap, a non-standard experience, or a mix of both
+- Do not automatically convert personal projects, writing, freelancing, self-media work, study periods, or transition periods into formal employment
+- Do not automatically collapse those periods into an empty gap either
+- If the timeline is unclear, ask for the start date, end date, and what the candidate was doing during that period before packaging it
+
+Minimum classification buckets:
+
+- `纯空档`: no sustained work, study, or project activity can be shown yet
+- `学习型 gap`: the candidate mainly studied, trained, prepared for transition, or built foundational knowledge
+- `项目型 gap`: the candidate worked on independent projects, freelance work, consulting, or hands-on side work
+- `创作型 gap`: the candidate spent the period on sustained creative output such as writing, content creation, or independent publishing
+- `混合型 gap`: the period includes a meaningful mix of study, project work, and non-standard output
+
+For every classified gap or non-standard period, make the analysis explicit about:
+
+- the approximate time range
+- whether the period is a gap, a non-standard experience, or both
+- which classification bucket it belongs to
+- what facts still need confirmation before any stronger packaging is attempted
+
+This issue only covers recognition and classification. Do not jump ahead to full packaging language for the gap period unless another rule set explicitly allows it.
+
 Supported template families:
 
 - Backend / server-side

--- a/docs/plans/2026-03-29-issue-24-gap-recognition.md
+++ b/docs/plans/2026-03-29-issue-24-gap-recognition.md
@@ -1,0 +1,67 @@
+# Issue #24 Gap Recognition Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add explicit gap-recognition and non-standard-experience classification rules so the skill can identify these periods before any packaging or interview guidance is attempted.
+
+**Architecture:** Keep the change at the rule layer. Extend `SKILL.md` with a dedicated section for gap recognition and classification, then add matching rule-test and validation coverage so the behavior can be checked without relying on vague intuition.
+
+**Tech Stack:** Markdown skill spec, validation reference docs, rule test cases, repository validation script.
+
+### Task 1: Add gap-recognition rules
+
+**Files:**
+- Modify: `SKILL.md`
+
+**Step 1: Define recognition-before-packaging**
+
+Document that:
+
+- gap periods must be identified before packaging
+- non-standard experiences should not be auto-converted into employment
+- those periods also should not be auto-collapsed into empty gaps
+
+**Step 2: Add classification buckets**
+
+Add at least:
+
+- 纯空档
+- 学习型 gap
+- 项目型 gap
+- 创作型 gap
+- 混合型 gap
+
+### Task 2: Add test coverage
+
+**Files:**
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Add a rule case for gap classification**
+
+The rule case should check that the skill classifies the period before packaging it.
+
+**Step 2: Add a validation scenario**
+
+Use a mixed example with:
+
+- transition preparation
+- fiction writing
+- personal content work
+
+Expected: classify first, ask for missing details, do not turn it directly into formal employment.
+
+### Task 3: Verify repository health
+
+**Files:**
+- No file changes expected
+
+**Step 1: Run repository checks**
+
+Run:
+
+```bash
+./scripts/run_checks.sh
+```
+
+Expected: repository checks pass.

--- a/references/rule-test-cases.md
+++ b/references/rule-test-cases.md
@@ -116,3 +116,26 @@ Each rule case should include:
 
 - 直接把个人项目写成公司任职
 - 把 gap 直接忽略成空白
+
+## Case 6: Gap Must Be Classified Before Packaging
+
+目标规则:
+
+- gap 或非标准经历要先分型，再决定后续怎么处理
+
+输入 prompt:
+
+`Use $job-copilot-skill to review my resume. I had a 9-month break where I was preparing for a transition, writing online fiction, and running a small personal content account.`
+
+期望行为:
+
+- 识别这是一个 gap 或非标准经历区间
+- 尝试将这段时间分类为学习型、创作型、项目型或混合型
+- 说明还缺哪些时间线或产出信息
+- 明确这一步先做识别，不直接跳到正式任职包装
+
+禁止行为:
+
+- 不做分型，直接进入强包装
+- 把这段时间简单归零成“没有经历”
+- 直接写成固定公司的正式工作

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -140,3 +140,17 @@ Expected behavior:
 - keep the campus project only as the main narrative if the newer work is clearly too weak or too unrelated
 - explain which experience is the current main narrative and which is supporting evidence
 - explain why the 2021 experience is downgraded or kept at the 2026-03-29 time point
+
+## Scenario 10: Gap And Non-Standard Experience Must Be Classified First
+
+Prompt:
+
+`Today is 2026-03-29. Use $job-copilot-skill to review my resume. I have a 9-month period in 2025 where I was not in a fixed company. During that time I prepared for a role transition, wrote online fiction, and ran a small personal content account.`
+
+Expected behavior:
+
+- recognize this as a gap or non-standard experience period instead of ignoring it
+- avoid converting the period directly into formal employment
+- classify the period as learning, project, creative, mixed, or explain why the current information is still insufficient
+- ask for time range, output, and continuity details if the classification is still ambiguous
+- make it clear that recognition comes before packaging


### PR DESCRIPTION
## 背景
close #24

当前 skill 缺少对 gap 期和非标准经历的识别与分类规则，容易出现两种错误：一是把这类经历直接忽略成空白，二是把它们直接写成正式任职。

## 本次改动
- 在 `SKILL.md` 中增加 `Gap And Non-Standard Experience Recognition` 规则段
- 明确 gap / 非标准经历需要先识别、先分类，再决定后续如何处理
- 增加五类最小分类桶：纯空档、学习型 gap、项目型 gap、创作型 gap、混合型 gap
- 明确必须补时间范围、连续性和产出信息，不能在信息不足时直接强包装
- 在 `references/rule-test-cases.md` 中增加 gap 分型规则用例
- 在 `references/validation-scenarios.md` 中增加 gap / 非标准经历识别场景
- 增加 `docs/plans/2026-03-29-issue-24-gap-recognition.md` 计划文档

## 不包含
- 不提供 gap 的正式包装文案模板
- 不处理 gap 的面试解释口径
- 不把个人项目直接升级为正式任职

## 验证
- `./scripts/run_checks.sh`
- 规则用例最小复测：
  - 是否存在专门的 gap 识别段
  - 是否存在五类最小分型
  - 是否要求先识别后包装
  - 是否补了 rule case 和 validation scenario

## 风险
- 主要风险是把所有非标准经历都过早归类为有效项目
- 当前通过“先分类 + 先补信息 + 不直接包装为正式任职”控制风险
