### PR TITLE
feat: 增加 Gap 期合理包装与面试解释规则

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -154,6 +154,51 @@ For every classified gap or non-standard period, make the analysis explicit abou
 
 This issue only covers recognition and classification. Do not jump ahead to full packaging language for the gap period unless another rule set explicitly allows it.
 
+## Gap Packaging Principles
+
+When a gap or non-standard period has already been identified and classified, the next goal is not to erase the gap. The goal is to explain it in a way that is truthful, stable, and relevant to the target role.
+
+Core packaging rules:
+
+- Treat the period as a gap with effective input, not as fake full-time employment
+- Do not invent company names, formal titles, teams, or commercial outcomes
+- Do not package the period as the candidate's main career highlight unless the support is unusually strong
+- Make it clear that the purpose is to reduce negative ambiguity, not to pretend the gap never existed
+
+Use gap packaging only when at least one of these is true:
+
+- the candidate had sustained output during the period
+- the candidate can describe real work, process, and continuity
+- the period produced transferable skills that clearly connect to the target role
+
+Resume-writing rules for packaged gap periods:
+
+- Prefer placing the period under `个人项目`, `补充经历`, or an equivalent non-employment section
+- Use labels such as `个人内容项目`, `独立项目`, or `个人创作项目` when that is what the work actually was
+- Focus on continuity, output, method, and transferable capability
+- If metrics are weak, use output and process clarity instead of invented impact claims
+- Explicitly avoid presenting the period as a formal company job when no formal employer existed
+
+Interview explanation rules for packaged gap periods:
+
+- First acknowledge the period honestly as a gap or non-standard work period
+- Then explain what the candidate was continuously doing during that time
+- Then explain what was produced, learned, or iterated on
+- Finally connect that period back to the target role and why it still matters now
+
+For creative or personal-project gaps, such as writing fiction or running a personal content project:
+
+- frame the period as sustained personal output, not fake institutional employment
+- emphasize continuity, content process, audience feedback, self-management, and transferable skills
+- avoid escalating it into professional scale unless the candidate can support real volume, traction, or monetization
+
+When giving wording suggestions, provide both:
+
+- a safer resume-ready version
+- a safer interview explanation version
+
+Always keep the explanation aligned with the earlier gap classification. Do not package a period as `项目型` or `创作型` in one place and then explain it like formal employment somewhere else.
+
 Supported template families:
 
 - Backend / server-side

--- a/docs/plans/2026-03-29-issue-25-gap-packaging.md
+++ b/docs/plans/2026-03-29-issue-25-gap-packaging.md
@@ -1,0 +1,60 @@
+# Issue #25 Gap Packaging Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add explicit gap-packaging and interview-explanation rules so identified gap periods can be explained more reasonably without being disguised as formal employment.
+
+**Architecture:** Build on the recognition layer from `#24`. Extend `SKILL.md` with a dedicated gap-packaging section, then add rule-test and validation coverage that checks for truthful packaging boundaries, safer resume placement, and safer interview explanation patterns.
+
+**Tech Stack:** Markdown skill spec, rule test cases, validation scenarios, repository validation script.
+
+### Task 1: Add gap-packaging rules
+
+**Files:**
+- Modify: `SKILL.md`
+
+**Step 1: Define packaging goals and boundaries**
+
+Document that:
+
+- the purpose is to explain the gap, not erase it
+- non-standard periods should not be rewritten as formal employment
+- packaging should reduce ambiguity while staying defensible
+
+**Step 2: Add resume and interview rules**
+
+Clarify:
+
+- safer resume placement
+- what labels are acceptable
+- how to explain the period in interviews
+- what not to fabricate
+
+### Task 2: Add test coverage
+
+**Files:**
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Add a rule case for gap packaging**
+
+The rule case should verify that the skill explains the gap without pretending it was formal employment.
+
+**Step 2: Add a validation scenario**
+
+Use a fiction-writing and personal-content-project example. Expected: acknowledge the gap, reduce ambiguity, and keep truthful boundaries.
+
+### Task 3: Verify repository health
+
+**Files:**
+- No file changes expected
+
+**Step 1: Run repository checks**
+
+Run:
+
+```bash
+./scripts/run_checks.sh
+```
+
+Expected: repository checks pass.

--- a/references/rule-test-cases.md
+++ b/references/rule-test-cases.md
@@ -139,3 +139,27 @@ Each rule case should include:
 - 不做分型，直接进入强包装
 - 把这段时间简单归零成“没有经历”
 - 直接写成固定公司的正式工作
+
+## Case 7: Gap Packaging Should Explain, Not Erase
+
+目标规则:
+
+- gap 包装的目标是合理解释，不是把 gap 洗成正式工作
+
+输入 prompt:
+
+`Use $job-copilot-skill to package my gap. I spent that period writing fiction and running a small personal content project, and I want it to look more reasonable on my resume and in interviews.`
+
+期望行为:
+
+- 先承认这是 gap 或非标准经历
+- 给出更安全的简历写法方向
+- 给出更安全的面试解释方向
+- 明确不要伪装成正式公司任职
+- 强调持续投入、产出或可迁移能力
+
+禁止行为:
+
+- 直接把这段时间写成固定公司经历
+- 为了好看而虚构职位、公司或商业化结果
+- 把 gap 写成核心高光但没有支撑

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -154,3 +154,17 @@ Expected behavior:
 - classify the period as learning, project, creative, mixed, or explain why the current information is still insufficient
 - ask for time range, output, and continuity details if the classification is still ambiguous
 - make it clear that recognition comes before packaging
+
+## Scenario 11: Gap Packaging Should Reduce Ambiguity Without Faking Employment
+
+Prompt:
+
+`Today is 2026-03-29. Use $job-copilot-skill to help me package a 2025 gap period. I was not in a fixed company, but I spent that time writing online fiction and running a personal content account. I want the gap to look more reasonable on my resume and in interviews.`
+
+Expected behavior:
+
+- acknowledge that this is still a gap or non-standard period
+- avoid converting it directly into formal employment
+- suggest a safer resume placement such as personal project or supplemental experience
+- suggest an interview explanation that first admits the gap, then explains sustained work and transferable skills
+- avoid fake companies, fake titles, or unsupported commercial scale


### PR DESCRIPTION
## 背景
close #25

在已经能识别和分型 gap / 非标准经历的基础上，这个 PR 继续补 gap 的合理包装原则。目标不是把 gap 洗掉，而是让这段经历在简历和面试中更合理、更稳定、也更不容易引发负面猜测。

## 本次改动
- 在 `SKILL.md` 中增加 `Gap Packaging Principles` 规则段
- 明确 gap 包装的目标是“合理解释”，不是“伪装成正式任职”
- 增加简历写法规则：放置位置、可用标签、表达重点和禁止事项
- 增加面试解释口径规则：先承认 gap，再说明持续投入、产出和能力沉淀
- 明确“写小说 / 个人内容项目”这类创作型 gap 的包装边界
- 在 `references/rule-test-cases.md` 中增加 gap 包装规则用例
- 在 `references/validation-scenarios.md` 中增加 gap 包装验证场景
- 增加 `docs/plans/2026-03-29-issue-25-gap-packaging.md` 计划文档

## 不包含
- 不把 gap 期写成正式公司任职
- 不虚构公司、职位或商业化结果
- 不把 gap 包装成主履历高光，除非后续另有强支撑规则

## 验证
- `./scripts/run_checks.sh`
- 规则用例最小复测：
  - 是否存在 gap 包装原则段
  - 是否有简历写法规则
  - 是否有面试解释口径规则
  - 是否覆盖“写小说 + 个人内容项目”典型案例
  - 是否补了对应 rule case 和 validation scenario

## 风险
- 主要风险是把“合理解释”误用成过度包装
- 当前通过“先承认 gap + 不伪装任职 + 强调持续投入和可迁移能力”控制风险
