### PR TITLE
feat: 重构简历包装教练流程为先诊断后追问

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -84,6 +84,34 @@ Rules for the status block:
 - Do not skip it just because the user asked for a faster result
 - If the skill is still in diagnosis or deep-dive, say so first rather than acting as if final packaging is already underway
 
+### Resume Packaging Coach Flow
+
+The resume packaging coach must diagnose before rewriting. Do not treat first-pass packaging as surface wording polish.
+
+Use this packaging order:
+
+1. Identify the strongest 1 to 3 experiences worth packaging first
+2. Explain what is currently weak in those experiences
+3. Recommend the packaging direction before rewriting
+4. Ask for missing support such as scope, ownership, baseline, timeline, or results
+5. Only then produce stronger wording or a more stable draft
+
+If the user asks for a direct rewrite but the supporting detail is still weak:
+
+- do not skip diagnosis
+- do not jump straight to a polished final version
+- give a provisional draft only if it is clearly marked as unstable
+- make the missing information explicit before treating any wording as ready
+
+Minimum packaging output per experience:
+
+- `当前问题`
+- `推荐包装方向`
+- `改写示例`
+- `补充建议 / 风险提醒`
+
+When information is incomplete, prioritize follow-up questions over shallow wording upgrades.
+
 ## Role Routing
 
 Infer the job family before deep rewriting. Use the closest primary track, then add a secondary track only when it materially changes questions or review criteria.
@@ -231,6 +259,7 @@ Responsibilities:
 
 - Clarify the candidate's target role, seniority, and strongest stories
 - Select the highest-upside projects instead of treating every line item equally
+- Diagnose what is weak before trying to beautify wording
 - Ask for business context, scope, actions, constraints, tradeoffs, metrics, and lessons
 - Build a candidate project packaging card before writing final bullets
 - Produce stronger resume wording, self-introduction drafts, and interview-ready storylines
@@ -247,6 +276,7 @@ Agent 1 is not allowed to:
 - Invent projects, ownership, metrics, or tech the candidate cannot defend
 - Treat team outcomes as personal outcomes without attribution
 - Hide uncertainty; mark unconfirmed items as gaps
+- Treat first-pass packaging as pure rewriting when diagnosis and follow-up are still missing
 
 ### Agent 2: Review And Calibrate
 

--- a/docs/plans/2026-03-29-issue-14-diagnose-before-rewrite.md
+++ b/docs/plans/2026-03-29-issue-14-diagnose-before-rewrite.md
@@ -1,0 +1,105 @@
+# Issue #14 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 让简历包装教练默认遵循“先诊断、再追问、后改写”的流程，而不是直接给最终润色稿。
+
+**Architecture:** 只修改 skill 规则与测试文档，不触碰其他岗位模板。先补规则用例和验证场景，再收紧 `SKILL.md` 中的主流程与包装教练职责。
+
+**Tech Stack:** Markdown, repo validation scripts, rule-based prompt tests
+
+### Task 1: Add failing expectations
+
+**Files:**
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Define the failing checks**
+
+Check for these markers after implementation:
+- `Resume Packaging Coach Flow`
+- `Case 8: Packaging Coach Must Diagnose Before Rewriting`
+- `Scenario 12: Packaging Must Diagnose Before Final Rewriting`
+
+**Step 2: Run the failing verification**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+base = Path('.')
+skill = (base / 'SKILL.md').read_text()
+rules = (base / 'references/rule-test-cases.md').read_text()
+scenarios = (base / 'references/validation-scenarios.md').read_text()
+assert 'Resume Packaging Coach Flow' in skill
+assert 'Case 8: Packaging Coach Must Diagnose Before Rewriting' in rules
+assert 'Scenario 12: Packaging Must Diagnose Before Final Rewriting' in scenarios
+PY
+```
+
+Expected: fail before implementation because the new flow, case, and scenario do not exist yet.
+
+### Task 2: Tighten the core workflow
+
+**Files:**
+- Modify: `SKILL.md`
+
+**Step 1: Add resume packaging coach flow**
+
+Insert a dedicated subsection under `## Core Workflow` that requires:
+- identify strongest 1 to 3 experiences first
+- explain current weakness
+- recommend packaging direction
+- ask for missing support
+- only then produce stronger wording
+
+**Step 2: Tighten Agent 1 behavior**
+
+Update Agent 1 responsibilities and restrictions so the first pass cannot be treated as pure rewriting.
+
+### Task 3: Add rule and scenario coverage
+
+**Files:**
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Add case 8**
+
+Cover the rule that packaging must diagnose and follow up before final rewriting.
+
+**Step 2: Add scenario 12**
+
+Cover the realistic user behavior of asking for a direct rewrite while the material is still under-supported.
+
+### Task 4: Verify and prepare PR
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+- Create: `docs/plans/2026-03-29-issue-14-diagnose-before-rewrite.md`
+
+**Step 1: Re-run the targeted verification**
+
+Run the same `python3` block from Task 1 and confirm it passes.
+
+**Step 2: Run repo validation**
+
+Run:
+
+```bash
+./scripts/run_checks.sh
+```
+
+Expected: pass.
+
+**Step 3: Commit and open PR**
+
+Commit with:
+
+```bash
+git commit -m "feat: require diagnose-before-rewrite packaging flow"
+```
+
+PR body must include `close #14`.

--- a/references/rule-test-cases.md
+++ b/references/rule-test-cases.md
@@ -163,3 +163,26 @@ Each rule case should include:
 - 直接把这段时间写成固定公司经历
 - 为了好看而虚构职位、公司或商业化结果
 - 把 gap 写成核心高光但没有支撑
+
+## Case 8: Packaging Coach Must Diagnose Before Rewriting
+
+目标规则:
+
+- 简历包装教练默认要先诊断、再追问、后改写
+
+输入 prompt:
+
+`Use $job-copilot-skill to rewrite my resume for product operations. My current project bullets feel flat, so give me a stronger version.`
+
+期望行为:
+
+- 先指出当前问题或最值得包装的经历
+- 先给推荐包装方向
+- 信息不足时先追问关键缺口
+- 如果给草案，要明确它还是临时版本
+
+禁止行为:
+
+- 第一轮直接给完整终稿
+- 只有措辞润色，没有诊断或方向判断
+- 在缺少职责、范围或结果支撑时假装内容已经稳定

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -168,3 +168,19 @@ Expected behavior:
 - suggest a safer resume placement such as personal project or supplemental experience
 - suggest an interview explanation that first admits the gap, then explains sustained work and transferable skills
 - avoid fake companies, fake titles, or unsupported commercial scale
+
+## Scenario 12: Packaging Must Diagnose Before Final Rewriting
+
+Prompt:
+
+`Today is 2026-03-29. Use $job-copilot-skill to rewrite my resume for product operations. My bullets feel ordinary, and I want a stronger version quickly.`
+
+Expected behavior:
+
+- start with the required status block
+- stay in `阶段 1：简历诊断与初步包装` if the skill is still assessing the material
+- identify which 1 to 3 experiences are the best packaging targets before rewriting
+- explain the current weakness or missing support in those experiences
+- ask for missing scope, ownership, baseline, or result details before treating any rewritten version as final
+- if a draft is provided, mark it as provisional rather than final
+- avoid jumping straight to a polished full rewrite with no diagnosis


### PR DESCRIPTION
## 摘要
- 为简历包装教练补充“先诊断、再追问、后改写”的显式流程
- 新增规则用例与验证场景，约束首轮不能直接跳到终稿润色
- 收紧 Agent 1 首轮行为，避免把包装直接做成表面措辞优化

## 关联 Issue
close #14

## 验证
- `python3` 断言检查 `Resume Packaging Coach Flow`、`Case 8`、`Scenario 12`
- `./scripts/run_checks.sh`

## 风险
- 这次只收紧包装流程，不调整审核官与高质量信号库逻辑
