### PR TITLE
feat: 升级包装结果结构为问题方向结果风险四段式

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -112,6 +112,27 @@ Minimum packaging output per experience:
 
 When information is incomplete, prioritize follow-up questions over shallow wording upgrades.
 
+### Packaging Result Structure
+
+Packaging output should read like `问题 + 方向 + 结果 + 风险`, not like a single rewritten paragraph dropped on the user.
+
+Use this standard structure whenever the packaging coach presents a strengthened version of an experience:
+
+- `当前问题`: what is weak, vague, misplaced, or under-supported right now
+- `推荐方向`: what capability, narrative angle, or value signal the experience should emphasize
+- `改写结果`: the stronger draft wording or provisional rewrite
+- `补充建议`: what facts, baselines, ownership detail, or support should be collected next
+- `风险提醒`: what still sounds over-packaged, unsupported, or likely to break under follow-up
+
+Keep it concise and conversational, but do not collapse these ideas into a single bullet.
+
+Boundary with the review officer:
+
+- the packaging coach owns `当前问题`、`推荐方向`、`改写结果`、`补充建议`
+- the review officer owns formal risk grading, current level judgment, upgrade calibration, and safer stronger wording after the review pass
+
+If support is still weak, the packaging coach may recommend a softer draft before the review officer decides whether the wording can stand.
+
 ## Role Routing
 
 Infer the job family before deep rewriting. Use the closest primary track, then add a secondary track only when it materially changes questions or review criteria.

--- a/docs/plans/2026-03-29-issue-17-packaging-structure.md
+++ b/docs/plans/2026-03-29-issue-17-packaging-structure.md
@@ -1,0 +1,107 @@
+# Issue #17 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 将包装结果固定为“问题、方向、结果、建议/风险”可见结构，并明确它与审核官输出的边界。
+
+**Architecture:** 在 `SKILL.md` 增加独立的包装结果结构说明，同时补规则用例和验证场景。不改 memory，不扩散到模板族。
+
+**Tech Stack:** Markdown, repo validation scripts, rule-based prompt tests
+
+### Task 1: Add failing expectations
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Define the failing checks**
+
+Check for these markers after implementation:
+- `### Packaging Result Structure`
+- `改写结果`
+- `风险提醒`
+- `Scenario 14: Packaging Output Must Show Problem Direction Result And Risk`
+
+**Step 2: Run the failing verification**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+base = Path('.')
+skill = (base / 'SKILL.md').read_text()
+scenarios = (base / 'references/validation-scenarios.md').read_text()
+assert '### Packaging Result Structure' in skill
+assert '改写结果' in skill
+assert '风险提醒' in skill
+assert 'Scenario 14: Packaging Output Must Show Problem Direction Result And Risk' in scenarios
+PY
+```
+
+Expected: fail before implementation.
+
+### Task 2: Fix the packaging output contract
+
+**Files:**
+- Modify: `SKILL.md`
+
+**Step 1: Define the standard packaging output**
+
+Require packaging output to clearly separate:
+- 当前问题
+- 推荐方向
+- 改写结果
+- 补充建议
+- 风险提醒
+
+**Step 2: Clarify the boundary with the review officer**
+
+State that packaging output explains the coach's current draft, while the review officer still owns risk grading, level judgment, and safer upgrade calibration.
+
+### Task 3: Add behavior coverage
+
+**Files:**
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Add a packaging output test case**
+
+Cover the expectation that packaging cannot collapse into one final rewritten paragraph.
+
+**Step 2: Add scenario 14**
+
+Cover a user asking for a stronger packaged version and verify that the output stays structured and conversational.
+
+### Task 4: Verify and prepare PR
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+- Create: `docs/plans/2026-03-29-issue-17-packaging-structure.md`
+
+**Step 1: Re-run targeted verification**
+
+Use the same `python3` block from Task 1 and confirm it passes.
+
+**Step 2: Run repository validation**
+
+Run:
+
+```bash
+./scripts/run_checks.sh
+```
+
+Expected: pass.
+
+**Step 3: Commit and open PR**
+
+Commit with:
+
+```bash
+git commit -m "feat: structure packaging output"
+```
+
+PR body must include `close #17`.

--- a/references/rule-test-cases.md
+++ b/references/rule-test-cases.md
@@ -188,3 +188,27 @@ Each rule case should include:
 - 第一轮直接给完整终稿
 - 只有措辞润色，没有诊断或方向判断
 - 在缺少职责、范围或结果支撑时假装内容已经稳定
+
+## Case 9: Packaging Output Must Stay Structured
+
+目标规则:
+
+- 包装结果必须让用户看见问题、方向、结果和风险，而不是只有改写稿
+
+输入 prompt:
+
+`Use $job-copilot-skill to package my strongest operations project and show me a stronger version.`
+
+期望行为:
+
+- 输出里能看见当前问题
+- 输出里能看见推荐方向
+- 输出里能看见改写结果
+- 输出里能看见补充建议或风险提醒
+- 对话仍然简洁，不变成大报告
+
+禁止行为:
+
+- 只给一段最终改写
+- 没有说明为什么这样改
+- 没有提示还缺什么支撑或有什么风险

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -199,3 +199,18 @@ Expected behavior:
 - the review pass should explain how to move the wording up one level safely
 - the review pass should provide a safer stronger expression the candidate can still defend
 - the review pass should avoid generic praise or generic caution with no actionable next step
+
+## Scenario 14: Packaging Output Must Show Problem Direction Result And Risk
+
+Prompt:
+
+`Today is 2026-03-29. Use $job-copilot-skill to package my strongest operations project into a stronger version for resume use, but keep the explanation easy to follow.`
+
+Expected behavior:
+
+- stay in the packaging flow instead of collapsing directly into one final bullet
+- show what the current weakness is
+- show the recommended packaging direction
+- show a stronger draft result
+- show what still needs supplement or what risks remain
+- keep the output conversational rather than turning it into a long report


### PR DESCRIPTION
## 摘要
- 为包装结果增加独立结构协议，避免只输出一段改写稿
- 固定包装输出的五个要素：当前问题、推荐方向、改写结果、补充建议、风险提醒
- 明确包装教练与审核官在输出职责上的边界

## 关联 Issue
close #17

## 验证
- `python3` 断言检查 `Packaging Result Structure`、`改写结果`、`风险提醒`、`Case 9`、`Scenario 14`
- `./scripts/run_checks.sh`

## 风险
- 这次只收紧包装输出协议，不扩展 memory 写回与审核官 rubric 之外的行为
