### PR TITLE
feat: 在项目包装卡片中加入时间轴与 gap 字段

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -374,6 +374,10 @@ Use [project-packaging-card-template.md](./assets/project-packaging-card-templat
 Minimum fields:
 
 - Project identity and time range
+- Whether the experience is recent core experience
+- Whether the experience belongs to a gap or non-standard period
+- Narrative position: main story, supporting story, or supplemental highlight
+- Timeline weighting note
 - One-line project definition
 - Business background and goal
 - Candidate responsibility boundary

--- a/assets/project-packaging-card-template.md
+++ b/assets/project-packaging-card-template.md
@@ -7,6 +7,10 @@
 - Company or business line:
 - Job family:
 - Tech or work context:
+- Is recent core experience:
+- Gap or non-standard period:
+- Narrative position:
+- Timeline weighting note:
 
 ## One-Line Definition
 

--- a/docs/plans/2026-03-29-issue-27-card-timeline-gap.md
+++ b/docs/plans/2026-03-29-issue-27-card-timeline-gap.md
@@ -1,0 +1,112 @@
+# Issue #27 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 让项目包装卡片能够承载时间轴权重、Gap 属性和主叙事定位，而不只是项目内容摘要。
+
+**Architecture:** 只修改项目包装卡片模板、主 skill 中的卡片字段说明，以及对应的规则用例和验证场景。不改 memory。
+
+**Tech Stack:** Markdown, repo validation scripts, rule-based prompt tests
+
+### Task 1: Add failing expectations
+
+**Files:**
+- Modify: `assets/project-packaging-card-template.md`
+- Modify: `SKILL.md`
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Define the failing checks**
+
+Check for these markers after implementation:
+- `Narrative Position`
+- `Is recent core experience`
+- `Gap or non-standard period`
+- `Case 11: Project Card Must Carry Timeline And Gap Signals`
+- `Scenario 16: Project Card Must Support Timeline And Narrative Sorting`
+
+**Step 2: Run the failing verification**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+base = Path('.')
+card = (base / 'assets/project-packaging-card-template.md').read_text()
+rules = (base / 'references/rule-test-cases.md').read_text()
+scenarios = (base / 'references/validation-scenarios.md').read_text()
+assert 'Narrative Position' in card
+assert 'Is recent core experience' in card
+assert 'Gap or non-standard period' in card
+assert 'Case 11: Project Card Must Carry Timeline And Gap Signals' in rules
+assert 'Scenario 16: Project Card Must Support Timeline And Narrative Sorting' in scenarios
+PY
+```
+
+Expected: fail before implementation.
+
+### Task 2: Expand the card template
+
+**Files:**
+- Modify: `assets/project-packaging-card-template.md`
+- Modify: `SKILL.md`
+
+**Step 1: Add timeline and narrative fields**
+
+Include fields for:
+- time weighting
+- whether it is recent core experience
+- whether it belongs to a gap or non-standard period
+- whether it is main narrative, supporting narrative, or only a supplemental highlight
+
+**Step 2: Update the skill-level card contract**
+
+Reflect the new required fields in `SKILL.md`.
+
+### Task 3: Add behavior coverage
+
+**Files:**
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Add rule case**
+
+Require the card to capture timeline, gap, and narrative position explicitly.
+
+**Step 2: Add scenario 16**
+
+Use a realistic prompt where older campus work, recent work, and a gap period all compete for placement.
+
+### Task 4: Verify and prepare PR
+
+**Files:**
+- Modify: `assets/project-packaging-card-template.md`
+- Modify: `SKILL.md`
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+- Create: `docs/plans/2026-03-29-issue-27-card-timeline-gap.md`
+
+**Step 1: Re-run targeted verification**
+
+Use the same `python3` block from Task 1 and confirm it passes.
+
+**Step 2: Run repository validation**
+
+Run:
+
+```bash
+./scripts/run_checks.sh
+```
+
+Expected: pass.
+
+**Step 3: Commit and open PR**
+
+Commit with:
+
+```bash
+git commit -m "feat: extend project card with timeline and gap fields"
+```
+
+PR body must include `close #27`.

--- a/references/rule-test-cases.md
+++ b/references/rule-test-cases.md
@@ -234,3 +234,25 @@ Each rule case should include:
 
 - 只输出泛泛的漂亮句子
 - 不区分岗位，套同一种强简历话术
+
+## Case 11: Project Card Must Carry Timeline And Gap Signals
+
+目标规则:
+
+- 项目包装卡片必须能表达时间权重、gap 属性和主叙事定位
+
+输入 prompt:
+
+`Use $job-copilot-skill to package my resume. I have a strong campus project, a recent operations project, and a gap-period content project.`
+
+期望行为:
+
+- 生成的项目卡片会标明是否为最近核心经历
+- 会标明是否属于 gap 或非标准经历
+- 会标明是主叙事、辅助叙事还是补充亮点
+- 会体现时间轴权重说明
+
+禁止行为:
+
+- 卡片只记录项目内容，不表达时间位置
+- 无法区分主线和补充经历

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -228,3 +228,16 @@ Expected behavior:
 - reflect a stronger expression structure or result strategy
 - make it clear what kind of strong-candidate signal the packaging is trying to surface
 - avoid treating the signal library like a raw template dump
+
+## Scenario 16: Project Card Must Support Timeline And Narrative Sorting
+
+Prompt:
+
+`Today is 2026-03-29. Use $job-copilot-skill to package my resume. I have a campus content project from 2021, store operations work from 2024, and a 2025 gap period where I ran a personal content account.`
+
+Expected behavior:
+
+- when creating project cards, mark which experience is recent core work
+- mark the 2025 content account period as gap or non-standard experience rather than formal employment
+- show which card is the main narrative, which is supporting evidence, and which is only a supplemental highlight
+- include an explicit timeline weighting note instead of relying on unstated judgment


### PR DESCRIPTION
## 摘要
- 为项目包装卡片补充时间轴、Gap 与主叙事定位字段
- 让卡片能够表达是否为最近核心经历、是否属于非标准经历、以及主线排序
- 同步补充规则用例和验证场景

## 关联 Issue
close #27

## 验证
- `python3` 断言检查卡片新增字段、`Case 11`、`Scenario 16`
- `./scripts/run_checks.sh`

## 风险
- 这次只扩展项目卡片，不修改 memory 模板
