### PR TITLE
feat: 在 memory 中记录主叙事与 gap 结论

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -374,10 +374,6 @@ Use [project-packaging-card-template.md](./assets/project-packaging-card-templat
 Minimum fields:
 
 - Project identity and time range
-- Whether the experience is recent core experience
-- Whether the experience belongs to a gap or non-standard period
-- Narrative position: main story, supporting story, or supplemental highlight
-- Timeline weighting note
 - One-line project definition
 - Business background and goal
 - Candidate responsibility boundary
@@ -400,6 +396,8 @@ The memory file should track:
 
 - Candidate profile and job-search targets
 - Current approved resume direction
+- Current main narrative and any downgraded older experiences
+- Gap explanation and non-standard experience handling conclusions
 - Project archive with statuses
 - Approved resume wording and self-introduction
 - Review risks and banned phrasing
@@ -414,6 +412,7 @@ Write only durable information:
 - Approved wording
 - Repeated weak points
 - Pending follow-ups
+- Narrative and gap conclusions should mark what is confirmed versus still pending
 
 Do not dump raw conversation transcripts into memory.
 

--- a/assets/memory-template.md
+++ b/assets/memory-template.md
@@ -23,6 +23,9 @@
 
 - Current main resume version:
 - Current positioning summary:
+- Current main narrative:
+- Downgraded older experiences:
+- Narrative decision status:
 - Main resume weaknesses:
 - Completed optimizations:
 - Remaining weak areas:
@@ -50,6 +53,8 @@
 - High-risk wording:
 - Banned or downgraded phrasing:
 - Data pending verification:
+- Gap explanation:
+- Non-standard experience conclusion:
 - Likely follow-up pressure points:
 
 ## 7. Mock Interview Notes

--- a/docs/plans/2026-03-29-issue-28-memory-narrative-gap.md
+++ b/docs/plans/2026-03-29-issue-28-memory-narrative-gap.md
@@ -1,0 +1,113 @@
+# Issue #28 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 让 memory 能记录主叙事选择、Gap 解释口径和旧经历降权结论，避免后续重复判断。
+
+**Architecture:** 只修改 memory 模板、主 skill 的 memory 说明、规则用例和验证场景。不改项目卡片。
+
+**Tech Stack:** Markdown, repo validation scripts, rule-based prompt tests
+
+### Task 1: Add failing expectations
+
+**Files:**
+- Modify: `assets/memory-template.md`
+- Modify: `SKILL.md`
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Define the failing checks**
+
+Check for these markers after implementation:
+- `Current main narrative`
+- `Downgraded older experiences`
+- `Gap explanation`
+- `Case 12: Memory Must Persist Narrative And Gap Conclusions`
+- `Scenario 17: Memory Should Persist Main Narrative And Gap Decisions`
+
+**Step 2: Run the failing verification**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+base = Path('.')
+memory = (base / 'assets/memory-template.md').read_text()
+rules = (base / 'references/rule-test-cases.md').read_text()
+scenarios = (base / 'references/validation-scenarios.md').read_text()
+assert 'Current main narrative' in memory
+assert 'Downgraded older experiences' in memory
+assert 'Gap explanation' in memory
+assert 'Case 12: Memory Must Persist Narrative And Gap Conclusions' in rules
+assert 'Scenario 17: Memory Should Persist Main Narrative And Gap Decisions' in scenarios
+PY
+```
+
+Expected: fail before implementation.
+
+### Task 2: Expand the memory template
+
+**Files:**
+- Modify: `assets/memory-template.md`
+- Modify: `SKILL.md`
+
+**Step 1: Add narrative and gap memory fields**
+
+Include fields for:
+- current main narrative
+- downgraded older experiences
+- gap explanation
+- non-standard experience conclusion
+- confirmed vs pending status
+
+**Step 2: Update the skill memory contract**
+
+Reflect these durable state requirements in `SKILL.md`.
+
+### Task 3: Add behavior coverage
+
+**Files:**
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Add rule case**
+
+Require memory to persist timeline and gap conclusions rather than dropping them after one session.
+
+**Step 2: Add scenario 17**
+
+Cover a realistic follow-up session where the assistant should reuse the stored main narrative and gap explanation.
+
+### Task 4: Verify and prepare PR
+
+**Files:**
+- Modify: `assets/memory-template.md`
+- Modify: `SKILL.md`
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+- Create: `docs/plans/2026-03-29-issue-28-memory-narrative-gap.md`
+
+**Step 1: Re-run targeted verification**
+
+Use the same `python3` block from Task 1 and confirm it passes.
+
+**Step 2: Run repository validation**
+
+Run:
+
+```bash
+./scripts/run_checks.sh
+```
+
+Expected: pass.
+
+**Step 3: Commit and open PR**
+
+Commit with:
+
+```bash
+git commit -m "feat: persist narrative and gap conclusions in memory"
+```
+
+PR body must include `close #28`.

--- a/references/rule-test-cases.md
+++ b/references/rule-test-cases.md
@@ -235,24 +235,23 @@ Each rule case should include:
 - 只输出泛泛的漂亮句子
 - 不区分岗位，套同一种强简历话术
 
-## Case 11: Project Card Must Carry Timeline And Gap Signals
+## Case 12: Memory Must Persist Narrative And Gap Conclusions
 
 目标规则:
 
-- 项目包装卡片必须能表达时间权重、gap 属性和主叙事定位
+- memory 需要持久化主叙事、旧经历降权结论和 gap 解释口径
 
 输入 prompt:
 
-`Use $job-copilot-skill to package my resume. I have a strong campus project, a recent operations project, and a gap-period content project.`
+`Use $job-copilot-skill to continue from last time. We already decided which experience is my main narrative and how to explain my 2025 gap.`
 
 期望行为:
 
-- 生成的项目卡片会标明是否为最近核心经历
-- 会标明是否属于 gap 或非标准经历
-- 会标明是主叙事、辅助叙事还是补充亮点
-- 会体现时间轴权重说明
+- 会依赖 memory 中已有的主叙事判断
+- 会依赖 memory 中已有的 gap 解释口径
+- 会区分哪些结论已确认，哪些还待补充
 
 禁止行为:
 
-- 卡片只记录项目内容，不表达时间位置
-- 无法区分主线和补充经历
+- 每次都重新判断主叙事，好像上次没有结论
+- 丢失 gap 解释，导致下一轮重新从头问

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -229,15 +229,15 @@ Expected behavior:
 - make it clear what kind of strong-candidate signal the packaging is trying to surface
 - avoid treating the signal library like a raw template dump
 
-## Scenario 16: Project Card Must Support Timeline And Narrative Sorting
+## Scenario 17: Memory Should Persist Main Narrative And Gap Decisions
 
 Prompt:
 
-`Today is 2026-03-29. Use $job-copilot-skill to package my resume. I have a campus content project from 2021, store operations work from 2024, and a 2025 gap period where I ran a personal content account.`
+`Today is 2026-03-29. Use $job-copilot-skill with my existing memory to continue resume prep. Last time we decided that my 2024 operations work is the main narrative, my 2021 campus project is supporting evidence, and my 2025 gap should be explained as a non-standard content project period.`
 
 Expected behavior:
 
-- when creating project cards, mark which experience is recent core work
-- mark the 2025 content account period as gap or non-standard experience rather than formal employment
-- show which card is the main narrative, which is supporting evidence, and which is only a supplemental highlight
-- include an explicit timeline weighting note instead of relying on unstated judgment
+- read and reuse the stored main narrative decision
+- keep the downgraded 2021 experience as supporting evidence instead of re-promoting it by default
+- reuse the stored gap explanation rather than asking from zero again
+- preserve which conclusions are confirmed and which still need support


### PR DESCRIPTION
## 摘要
- 为 memory 模板补充主叙事、旧经历降权和 gap 解释字段
- 明确这些判断应作为长期状态保留，而不是每轮重复推理
- 同步补充规则用例和验证场景

## 关联 Issue
close #28

## 验证
- `python3` 断言检查 memory 新字段、`Case 12`、`Scenario 17`
- `./scripts/run_checks.sh`

## 风险
- 这次只扩展 memory 模板与规则，不重做整体 memory 结构
