### PR TITLE
feat: 打通流程状态、项目卡片与 memory 联动

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -374,6 +374,10 @@ Use [project-packaging-card-template.md](./assets/project-packaging-card-templat
 Minimum fields:
 
 - Project identity and time range
+- Whether the experience is recent core experience
+- Whether the experience belongs to a gap or non-standard period
+- Narrative position: main story, supporting story, or supplemental highlight
+- Timeline weighting note
 - One-line project definition
 - Business background and goal
 - Candidate responsibility boundary
@@ -396,8 +400,6 @@ The memory file should track:
 
 - Candidate profile and job-search targets
 - Current approved resume direction
-- Current main narrative and any downgraded older experiences
-- Gap explanation and non-standard experience handling conclusions
 - Project archive with statuses
 - Approved resume wording and self-introduction
 - Review risks and banned phrasing
@@ -412,9 +414,38 @@ Write only durable information:
 - Approved wording
 - Repeated weak points
 - Pending follow-ups
-- Narrative and gap conclusions should mark what is confirmed versus still pending
 
 Do not dump raw conversation transcripts into memory.
+
+## Flow-State And Memory Link
+
+Stage labels must stay visible in the conversation, but not every stage detail belongs in long-term memory.
+
+Use this boundary:
+
+- `当前阶段 / 当前任务 / 下一步推荐` are session-facing state and should be shown in the conversation
+- reviewed milestone decisions should be written into memory when they will matter next session
+- project-level progress should live in the project packaging card first, then be summarized into memory only when it becomes durable
+
+Persist into memory when the result is stable enough to reuse:
+
+- current approved workflow stage for the candidate
+- whether the next session should resume from stage 1, 2, 3, or 4
+- main narrative decisions, downgraded older experiences, and gap explanations
+- approved wording, banned phrasing, and still-open follow-ups
+
+Do not persist into memory:
+
+- every intermediate status block
+- every temporary packaging guess
+- every back-and-forth clarification that has not yet become a stable conclusion
+
+Session resume rule:
+
+- read memory first
+- detect the last durable workflow stage
+- resume from that stage unless the new user request clearly resets the workflow
+- use project cards to recover project-level context before asking duplicate questions
 
 ## Mock Interview Pattern
 

--- a/assets/memory-template.md
+++ b/assets/memory-template.md
@@ -23,9 +23,8 @@
 
 - Current main resume version:
 - Current positioning summary:
-- Current main narrative:
-- Downgraded older experiences:
-- Narrative decision status:
+- Current workflow stage:
+- Resume from stage:
 - Main resume weaknesses:
 - Completed optimizations:
 - Remaining weak areas:
@@ -53,8 +52,6 @@
 - High-risk wording:
 - Banned or downgraded phrasing:
 - Data pending verification:
-- Gap explanation:
-- Non-standard experience conclusion:
 - Likely follow-up pressure points:
 
 ## 7. Mock Interview Notes

--- a/assets/project-packaging-card-template.md
+++ b/assets/project-packaging-card-template.md
@@ -11,6 +11,7 @@
 - Gap or non-standard period:
 - Narrative position:
 - Timeline weighting note:
+- Resume from stage:
 
 ## One-Line Definition
 

--- a/docs/plans/2026-03-29-issue-18-flow-memory-link.md
+++ b/docs/plans/2026-03-29-issue-18-flow-memory-link.md
@@ -1,0 +1,116 @@
+# Issue #18 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 明确流程状态、项目卡片与 memory 的联动边界，让后续会话可以基于上次进度恢复，而不是从头开始。
+
+**Architecture:** 只修改 `SKILL.md`、memory 模板、项目卡片模板以及规则用例/验证场景，定义哪些阶段信息要持久化、哪些只属于当前会话。
+
+**Tech Stack:** Markdown, repo validation scripts, rule-based prompt tests
+
+### Task 1: Add failing expectations
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `assets/memory-template.md`
+- Modify: `assets/project-packaging-card-template.md`
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Define the failing checks**
+
+Check for these markers after implementation:
+- `## Flow-State And Memory Link`
+- `Current workflow stage`
+- `Resume from stage`
+- `Case 13: Memory And Project Cards Must Support Session Resume`
+- `Scenario 18: Follow-Up Session Should Resume From Stored Progress`
+
+**Step 2: Run the failing verification**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+base = Path('.')
+skill = (base / 'SKILL.md').read_text()
+memory = (base / 'assets/memory-template.md').read_text()
+card = (base / 'assets/project-packaging-card-template.md').read_text()
+rules = (base / 'references/rule-test-cases.md').read_text()
+scenarios = (base / 'references/validation-scenarios.md').read_text()
+assert '## Flow-State And Memory Link' in skill
+assert 'Current workflow stage' in memory
+assert 'Resume from stage' in card
+assert 'Case 13: Memory And Project Cards Must Support Session Resume' in rules
+assert 'Scenario 18: Follow-Up Session Should Resume From Stored Progress' in scenarios
+PY
+```
+
+Expected: fail before implementation.
+
+### Task 2: Define the flow-memory boundary
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `assets/memory-template.md`
+- Modify: `assets/project-packaging-card-template.md`
+
+**Step 1: Add a dedicated flow-memory section**
+
+Document:
+- which stage state is transient
+- which milestone decisions should be persisted
+- how project cards and memory split responsibility
+
+**Step 2: Add resume-oriented fields**
+
+Add fields that help later sessions resume from the right stage without replaying the whole workflow.
+
+### Task 3: Add behavior coverage
+
+**Files:**
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+
+**Step 1: Add rule case**
+
+Require memory and project cards to support stage-aware resume behavior.
+
+**Step 2: Add scenario 18**
+
+Use a realistic second-session prompt that should continue from stored progress rather than restarting.
+
+### Task 4: Verify and prepare PR
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `assets/memory-template.md`
+- Modify: `assets/project-packaging-card-template.md`
+- Modify: `references/rule-test-cases.md`
+- Modify: `references/validation-scenarios.md`
+- Create: `docs/plans/2026-03-29-issue-18-flow-memory-link.md`
+
+**Step 1: Re-run targeted verification**
+
+Use the same `python3` block from Task 1 and confirm it passes.
+
+**Step 2: Run repository validation**
+
+Run:
+
+```bash
+./scripts/run_checks.sh
+```
+
+Expected: pass.
+
+**Step 3: Commit and open PR**
+
+Commit with:
+
+```bash
+git commit -m "feat: link flow state with memory and project cards"
+```
+
+PR body must include `close #18`.

--- a/references/rule-test-cases.md
+++ b/references/rule-test-cases.md
@@ -235,23 +235,45 @@ Each rule case should include:
 - 只输出泛泛的漂亮句子
 - 不区分岗位，套同一种强简历话术
 
-## Case 12: Memory Must Persist Narrative And Gap Conclusions
+## Case 13: Memory And Project Cards Must Support Session Resume
 
 目标规则:
 
-- memory 需要持久化主叙事、旧经历降权结论和 gap 解释口径
+- memory 和项目卡片要能支撑下一次从正确阶段继续，而不是默认从头开始
 
 输入 prompt:
 
-`Use $job-copilot-skill to continue from last time. We already decided which experience is my main narrative and how to explain my 2025 gap.`
+`Use $job-copilot-skill to continue from last time. We already finished project deep-dive and only need reviewed wording plus the next interview drills.`
 
 期望行为:
 
-- 会依赖 memory 中已有的主叙事判断
-- 会依赖 memory 中已有的 gap 解释口径
-- 会区分哪些结论已确认，哪些还待补充
+- 会识别这不是第一次 intake
+- 会根据已记录状态恢复到合适阶段
+- 会利用项目卡片和 memory 避免重复追问已确认内容
 
 禁止行为:
 
-- 每次都重新判断主叙事，好像上次没有结论
-- 丢失 gap 解释，导致下一轮重新从头问
+- 每次都默认从阶段 1 重新开始
+- 忽略上一次已确认的阶段进度
+
+## Case 11: Project Card Must Carry Timeline And Gap Signals
+
+目标规则:
+
+- 项目包装卡片必须能表达时间权重、gap 属性和主叙事定位
+
+输入 prompt:
+
+`Use $job-copilot-skill to package my resume. I have a strong campus project, a recent operations project, and a gap-period content project.`
+
+期望行为:
+
+- 生成的项目卡片会标明是否为最近核心经历
+- 会标明是否属于 gap 或非标准经历
+- 会标明是主叙事、辅助叙事还是补充亮点
+- 会体现时间轴权重说明
+
+禁止行为:
+
+- 卡片只记录项目内容，不表达时间位置
+- 无法区分主线和补充经历

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -229,15 +229,29 @@ Expected behavior:
 - make it clear what kind of strong-candidate signal the packaging is trying to surface
 - avoid treating the signal library like a raw template dump
 
-## Scenario 17: Memory Should Persist Main Narrative And Gap Decisions
+## Scenario 18: Follow-Up Session Should Resume From Stored Progress
 
 Prompt:
 
-`Today is 2026-03-29. Use $job-copilot-skill with my existing memory to continue resume prep. Last time we decided that my 2024 operations work is the main narrative, my 2021 campus project is supporting evidence, and my 2025 gap should be explained as a non-standard content project period.`
+`Today is 2026-03-29. Use $job-copilot-skill with my existing memory to continue from the last session. We already finished project deep-dive, selected the main narrative, and only need reviewed wording plus the next interview drill.`
 
 Expected behavior:
 
-- read and reuse the stored main narrative decision
-- keep the downgraded 2021 experience as supporting evidence instead of re-promoting it by default
-- reuse the stored gap explanation rather than asking from zero again
-- preserve which conclusions are confirmed and which still need support
+- read memory first
+- identify the stored workflow stage and resume from it
+- avoid replaying full intake and routing if those are already settled
+- use stored project-card context and durable memory conclusions to continue the work
+- only reset to an earlier stage if the new request clearly changes the target role or candidate story
+
+## Scenario 16: Project Card Must Support Timeline And Narrative Sorting
+
+Prompt:
+
+`Today is 2026-03-29. Use $job-copilot-skill to package my resume. I have a campus content project from 2021, store operations work from 2024, and a 2025 gap period where I ran a personal content account.`
+
+Expected behavior:
+
+- when creating project cards, mark which experience is recent core work
+- mark the 2025 content account period as gap or non-standard experience rather than formal employment
+- show which card is the main narrative, which is supporting evidence, and which is only a supplemental highlight
+- include an explicit timeline weighting note instead of relying on unstated judgment


### PR DESCRIPTION
## 摘要
- 明确流程状态、项目卡片与 memory 的联动边界
- 增加可恢复会话的字段，避免每次从阶段 1 重来
- 同步补充规则用例和验证场景

## 关联 Issue
close #18

## 验证
- `python3` 断言检查 Flow-State And Memory Link、恢复字段、`Case 13`、`Scenario 18`
- `./scripts/run_checks.sh`

## 风险
- 这次只定义边界与恢复机制，不重做整个 memory 系统
