### PR TITLE
feat: combine segmented role libraries, explanation layer, and pressure chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Job Copilot 使用写审分离的机制：
 
 这意味着它不是无约束地“写得更厉害”，而是在“更强表达”和“可讲述性”之间找平衡。
 
+现在它还要求给出解释层：为什么某个项目被提升为主叙事，为什么另一个项目只能作为辅助叙事或 gap 解释，以及当前为什么仍停留在某个阶段。
+
 ### 2. 动态岗位模板
 
 Job Copilot 不会默认把所有简历都当成后端简历处理。  
@@ -54,6 +56,11 @@ Job Copilot 不会默认把所有简历都当成后端简历处理。
 - 销售
 - 运营（含自媒体运营）
 
+在此基础上，系统还开始支持更细的岗位参考层，例如：
+
+- 内容运营 / 自媒体运营
+- 风控 / 反爬后端
+
 ### 3. 项目深挖卡片
 
 在正式改简历之前，Job Copilot 会先构建项目包装卡片，用来明确：
@@ -68,6 +75,8 @@ Job Copilot 不会默认把所有简历都当成后端简历处理。
 
 这样简历优化不再是“直接改文案”，而是先有结构化分析，再有最终输出。
 
+卡片里不仅要写“怎么包装”，还要写“为什么这样排序”和“更强写法为什么暂时不安全”。
+
 ### 4. 长期记忆
 
 Job Copilot 支持 `memory.md` 长期记忆，用来记录：
@@ -81,6 +90,8 @@ Job Copilot 支持 `memory.md` 长期记忆，用来记录：
 
 这让它更像一个长期陪跑教练，而不是一次性工具。
 
+对于长对话场景，`memory.md` 也会帮助系统记录当前阶段阻塞点和下一阶段进入条件，避免聊久了只剩模糊感。
+
 ### 5. 模拟面试与错题追踪
 
 当简历和项目故事通过审核后，Job Copilot 会继续做模拟面试训练，包括：
@@ -91,6 +102,8 @@ Job Copilot 支持 `memory.md` 长期记忆，用来记录：
 - 行为面
 
 每轮训练产生的薄弱点都会进入错题记录，支持后续持续复训。
+
+对于细分岗位，模拟面试不再只是一组通用追问，而会逐步切换到对应方向的高压追问题链。
 
 ## 它解决的问题
 
@@ -116,72 +129,10 @@ Job Copilot 更关注的是：
 - 这段经历是否真的值得包装
 - 这段包装是否能撑住连续追问
 - 这份简历是否真的像目标岗位候选人
+- 这套主叙事排序是否说得清理由
 - 这套故事是否能在下一轮训练里继续复用
 
 目标不是让简历“看起来强”，而是让候选人“真的能讲住这份强简历”。
-
-## Installation / 安装
-
-### 1. Prompt 安装
-
-一句话直接让当前 AI 帮你安装：
-
-```text
-请把 https://github.com/InRainbowsX/job-copilot-skill 安装为当前环境可用的 skill，目录名使用 job-copilot-skill，如果已安装则更新，并在完成后告诉我如何调用它。
-```
-
-### 2. 一键脚本安装
-
-默认自动识别当前环境，优先安装到 Claude Code、Codex 或 OpenClaw 的标准 skills 目录。
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/InRainbowsX/job-copilot-skill/main/install.sh | bash
-```
-
-也可以显式指定环境：
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/InRainbowsX/job-copilot-skill/main/install.sh | bash -s -- claude
-curl -fsSL https://raw.githubusercontent.com/InRainbowsX/job-copilot-skill/main/install.sh | bash -s -- codex
-curl -fsSL https://raw.githubusercontent.com/InRainbowsX/job-copilot-skill/main/install.sh | bash -s -- openclaw
-```
-
-对应安装目录：
-
-- `Claude Code`: `~/.claude/skills/job-copilot-skill`
-- `Codex`: `~/.codex/skills/job-copilot-skill`
-- `OpenClaw`: `~/.openclaw/skills/job-copilot-skill`
-
-### 3. 手动 clone 安装
-
-如果你更希望手动管理 skill，可以直接 clone 到目标目录。
-
-Claude Code:
-
-```bash
-mkdir -p ~/.claude/skills
-git clone https://github.com/InRainbowsX/job-copilot-skill.git ~/.claude/skills/job-copilot-skill
-```
-
-Codex:
-
-```bash
-mkdir -p ~/.codex/skills
-git clone https://github.com/InRainbowsX/job-copilot-skill.git ~/.codex/skills/job-copilot-skill
-```
-
-OpenClaw:
-
-```bash
-mkdir -p ~/.openclaw/skills
-git clone https://github.com/InRainbowsX/job-copilot-skill.git ~/.openclaw/skills/job-copilot-skill
-```
-
-安装完成后，推荐用这句话开始：
-
-```text
-使用 $job-copilot-skill，基于我的原始简历和自我介绍，识别岗位方向并开始深挖项目。
-```
 
 ## 仓库结构
 
@@ -195,8 +146,12 @@ git clone https://github.com/InRainbowsX/job-copilot-skill.git ~/.openclaw/skill
 │   ├── memory-template.md
 │   └── project-packaging-card-template.md
 └── references/
+    ├── content-operations-interview-chain.md
+    ├── content-operations-patterns.md
     ├── job-families.md
     ├── review-rubric.md
+    ├── risk-control-backend-interview-chain.md
+    ├── risk-control-backend-patterns.md
     └── validation-scenarios.md
 ```
 
@@ -240,12 +195,14 @@ Use $job-copilot-skill with my approved resume version to run a mock interview f
 - 项目包装卡片模板
 - memory 模板
 - 模拟面试错题模板
+- 细分岗位参考层基础版本
+- 长对话阶段刷新基础规则
 
 下一步重点是：
 
-- 补全更细的岗位专属模板
-- 增加真实案例 forward test
-- 继续优化 prompt 和 check points
+- 继续扩展更多细分岗位模式库
+- 增加更多真实案例 forward test
+- 继续提升岗位化 reviewer 和 interviewer 的质感
 
 ## 项目定位
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,9 @@ description: Use when improving, packaging, or stress-testing an internet job se
 
 Run internet job-search coaching as a controlled system, not as one-off copy editing. Infer the target role from the candidate's materials, deepen the strongest projects, upgrade the narrative, then pressure-test the result through a separate review pass before treating any wording as final.
 
-The core pattern is `简历包装教练先写，审核官再审`. The packaging coach pulls signal out of weak or incomplete material; the review officer challenges unsupported claims, over-packaging, and role mismatch while showing the safest way to strengthen a draft. Keep a running `memory.md` so future sessions resume from the candidate's actual state.
+The core pattern is `Agent 1 writes, Agent 2 reviews`. Agent 1 pulls signal out of weak or incomplete material; Agent 2 challenges unsupported claims, over-packaging, and role mismatch. Keep a running `memory.md` so future sessions resume from the candidate's actual state.
+
+The system must also explain itself. It is not enough to output a stronger package. The user should be able to understand why a project became the main story, why another project stayed secondary, why a gap-period item was downgraded, and what would be needed to advance to the next stage.
 
 ## When to Use
 
@@ -31,301 +33,28 @@ Do not use this skill for:
 
 Follow this sequence every time. Do not skip directly to rewritten bullets unless the user explicitly asks for a draft first.
 
-The user should be able to tell where they are in the process at a glance. Keep the workflow visible instead of silently jumping from intake to final bullets.
-
 | Step | Goal | Output |
 |---|---|---|
 | `1. Intake` | Read resume, self-introduction, and any JD or target role hints | Candidate snapshot |
 | `2. Role Routing` | Infer main and secondary job track from the materials | Selected template family |
 | `3. Agent 1 Deep-Dive` | Ask targeted questions, extract missing project detail, propose stronger positioning | Project packaging cards, draft wording |
-| `4. 审核官 Review` | Audit truthfulness, role fit, explainability, and interview survivability | Risk report, missing-info requests, downgrade advice |
+| `4. Agent 2 Review` | Audit truthfulness, role fit, explainability, and interview survivability | Risk report, missing-info requests, downgrade advice |
 | `5. Consolidate` | Keep only reviewed wording and summarize what still needs work | Resume sections, self-introduction, action list |
 | `6. Train` | Run mock interviews against the reviewed version | Interview notes, error log, next drills |
 | `7. Persist` | Update long-term memory with confirmed facts and recurring gaps | `memory.md` |
 
-### Real Resume Decomposition Report
+At the end of any stage that changes the user's next action, provide a short stage refresh containing:
 
-Before stable packaging, the skill must first understand the resume as a structured system rather than as disconnected bullets.
+- current stage
+- why the process is still in that stage
+- blocker or missing support
+- condition to exit the stage
 
-Use [resume-decomposition-report.md](./references/resume-decomposition-report.md).
-
-The `真实简历系统拆解报告` is the shared input between the `简历包装教练` and the `审核官`.
-
-Rules:
-
-- Build or summarize the decomposition report before treating packaging as stable
-- Use the report to explain what the skill already understands from the resume before rewriting major sections
-- Keep the decomposition report separate from final resume copy; it is an analysis layer, not the final deliverable
-- The report should be reusable across later packaging, review, interview, and memory updates
-- If the resume is still ambiguous, the report should make the ambiguity explicit instead of hiding it behind polished wording
-
-Minimum decomposition dimensions:
-
-- current analysis date and target-role routing
-- timeline breakdown
-- `主叙事 / 辅助叙事 / 补充亮点`
-- metric-caliber and ownership-risk notes
-- gap / non-standard experience conclusion
-- transferable capabilities
-- interview pressure points
-- next deep-dive priorities
-
-The decomposition report should help the user feel that the skill has actually understood the resume before packaging it.
-
-### Visible Stage Model
-
-Map the workflow to four user-facing stages and keep those stage names stable:
-
-| 阶段 | 覆盖步骤 | 用途 |
-|---|---|---|
-| `阶段 1：简历诊断与初步包装` | `1. Intake` + `2. Role Routing` + early `3. Agent 1 Deep-Dive` | 识别岗位方向、指出核心问题、决定优先包装的经历 |
-| `阶段 2：项目深挖与补强` | remaining `3. Agent 1 Deep-Dive` | 围绕高潜力项目追问背景、职责、难点、结果和支撑细节 |
-| `阶段 3：包装定稿与讲述稿生成` | `4. 审核官 Review` + `5. Consolidate` | 在审核通过后输出可用表述、风险提醒和讲述版本 |
-| `阶段 4：模拟面试与错题复盘` | `6. Train` + `7. Persist` | 基于已审核版本进行面试训练、记录错题并更新长期记忆 |
-
-Do not introduce alternate stage names unless the repository explicitly adds them later.
-
-### Turn-Level Status Block
-
-The status block is required, not optional.
-
-At the start of each meaningful response, include a short status block that makes the workflow explicit.
-
-You must begin the response with this status block in all of these cases:
-
-- the first meaningful response after the user provides a resume, self-introduction, or target role
-- any response that moves the workflow into a new stage
-- any response where the user asks for rewriting but the skill still needs diagnosis, routing, or follow-up questions
-
-Minimum fields:
-
-- `当前阶段`
-- `当前任务`
-- `下一步推荐`
-
-Rules for the status block:
-
-- Keep it concise: one short line or one short bullet per field is enough
-- Keep it conversational, not report-heavy
-- Put it before deeper analysis or rewritten content
-- Match the real workflow state; do not claim later stages are in progress if the skill is still collecting facts
-- When still in early packaging, explicitly signal that deeper project follow-up or interview training comes later
-- Do not skip it just because the user asked for a faster result
-- If the skill is still in diagnosis or deep-dive, say so first rather than acting as if final packaging is already underway
-
-### Resume Packaging Coach Flow
-
-The resume packaging coach must diagnose before rewriting. Do not treat first-pass packaging as surface wording polish.
-
-Before stable final wording, the packaging coach must produce a packaging plan.
-
-Use [packaging-plan-template.md](./references/packaging-plan-template.md).
-
-Use this packaging order:
-
-1. Produce a `真实简历系统拆解报告` or a concise decomposition summary first
-2. Identify the strongest 1 to 3 experiences worth packaging first
-3. Explain what is currently weak in those experiences
-4. Produce a packaging plan that sets the main narrative, supporting narrative, and per-experience packaging goal
-5. Ask for missing support such as scope, ownership, baseline, timeline, or results
-6. Let the review officer challenge the plan itself when the path is too aggressive or too weak
-6. Only then produce stronger wording or a more stable draft
-
-If the user asks for a direct rewrite but the supporting detail is still weak:
-
-- do not skip diagnosis
-- do not skip the decomposition layer
-- do not skip the packaging-plan layer
-- do not jump straight to a polished final version
-- give a provisional draft only if it is clearly marked as unstable
-- make the missing information explicit before treating any wording as ready
-
-Before major packaging, the packaging coach should be able to answer in plain language:
-
-- what the resume is mainly about
-- which experience carries the current main narrative
-- which items are only support or supplemental highlights
-- where the ownership, metric, or timeline risks are
-- what should be deepened next
-
-Minimum packaging output per experience:
-
-- `当前问题`
-- `推荐包装方向`
-- `改写示例`
-- `补充建议 / 风险提醒`
-
-When information is incomplete, prioritize follow-up questions over shallow wording upgrades.
-
-The packaging plan should make these decisions explicit before stable rewriting:
-
-- the main packaging direction
-- the narrative order across experiences
-- what each experience should signal
-- what must be supplemented
-- what must be downgraded
-- whether there is a safer and a stronger version worth showing side by side
-
-### Packaging Result Structure
-
-Packaging output should read like `问题 + 方向 + 结果 + 风险`, not like a single rewritten paragraph dropped on the user.
-
-Use this standard structure whenever the packaging coach presents a strengthened version of an experience:
-
-- `当前问题`: what is weak, vague, misplaced, or under-supported right now
-- `推荐方向`: what capability, narrative angle, or value signal the experience should emphasize
-- `改写结果`: the stronger draft wording or provisional rewrite
-- `补充建议`: what facts, baselines, ownership detail, or support should be collected next
-- `风险提醒`: what still sounds over-packaged, unsupported, or likely to break under follow-up
-
-Keep it concise and conversational, but do not collapse these ideas into a single bullet.
-
-Boundary with the review officer:
-
-- the packaging coach owns `当前问题`、`推荐方向`、`改写结果`、`补充建议`
-- the review officer owns formal risk grading, current level judgment, upgrade calibration, safer stronger wording after the review pass, and whether the packaging plan itself is sound
-
-If support is still weak, the packaging coach may recommend a softer draft before the review officer decides whether the wording can stand.
+In long conversations, refresh this more explicitly instead of relying on implication alone.
 
 ## Role Routing
 
 Infer the job family before deep rewriting. Use the closest primary track, then add a secondary track only when it materially changes questions or review criteria.
-
-## Timeline Priority
-
-Evaluate experience on a timeline before locking the main narrative. Do not choose the main story only because one older project sounds brighter on paper.
-
-Default weighting rules:
-
-- Anchor the timeline analysis to the current session date, not to a vague sense of "recent" or "too far"
-- If the current date is known, state it explicitly in the analysis before judging which experience should carry the main narrative
-- Compare actual experience time ranges against the current date whenever the timeline materially affects the conclusion
-- In social-hire contexts, prioritize recent 1 to 3 year experience first
-- Recent experience should normally outrank distant campus experience when both can support the target role
-- Role relevance still matters; recent but irrelevant experience should not automatically beat weaker but clearly relevant experience
-- The main narrative should answer: what is this candidate doing most recently, and does it support the target role now?
-
-Use campus experience as the main narrative only when at least one of these is true:
-
-- the recent work is too weak to support the target role
-- the recent work is clearly unrelated and cannot be reframed without distortion
-- the candidate is still close enough to an entry-level transition that campus work is the strongest real signal
-
-Downgrade campus experience to supporting evidence when:
-
-- the candidate is in a social-hire context and recent work can carry the role
-- the campus project is strong but too far from the current hiring moment
-- it works better as proof of early potential, content sense, or foundational skills than as the present-day main story
-
-When timeline weighting affects the result, make it explicit in the analysis:
-
-- what current date or hiring moment the analysis is using
-- what the relevant time ranges are for the newer work and the older experience
-- which experience is the current main narrative
-- which older experience is retained as supporting evidence
-- why the older experience was downgraded or kept
-
-If the case is borderline, do not just say an older experience is "too far" or "still usable." Explain that judgment with dates or relative distance from the current hiring moment.
-
-## High-Quality Resume Signal Library
-
-Use a role-specific signal library instead of relying on generic beautification. The library is not a dump of raw resume samples; it is a structured reference for what stronger internet-job resumes usually signal and how they organize that signal.
-
-Use [high-quality-signal-library.md](./references/high-quality-signal-library.md).
-
-The v1 library covers:
-
-- 后端
-- 产品
-- 运营
-- 销售
-
-Each family in the library should be used for four things:
-
-- `高质量信号`: what makes the experience read as stronger for that role
-- `高质量表达结构`: how strong bullets or stories are usually organized
-- `结果表达策略`: how outcomes should be expressed more professionally and credibly
-- `包装升级策略`: how to move ordinary experience up one level without fabricating
-
-How to use it:
-
-- 简历包装教练 uses it to choose the packaging angle, decide which follow-up questions matter most, and avoid shallow rewriting
-- 审核官 uses it to judge the current level of a draft, spot missing high-value signals, and suggest a safer stronger version
-
-## Gap And Non-Standard Experience Recognition
-
-Do not treat every gap as a blank period, and do not treat every non-company experience as fake employment.
-
-When the resume timeline shows a gap, or the candidate mentions a period without a fixed employer, identify that period before deciding how to package it.
-
-Recognition rules:
-
-- First determine whether the period is a true blank gap, a non-standard experience, or a mix of both
-- Do not automatically convert personal projects, writing, freelancing, self-media work, study periods, or transition periods into formal employment
-- Do not automatically collapse those periods into an empty gap either
-- If the timeline is unclear, ask for the start date, end date, and what the candidate was doing during that period before packaging it
-
-Minimum classification buckets:
-
-- `纯空档`: no sustained work, study, or project activity can be shown yet
-- `学习型 gap`: the candidate mainly studied, trained, prepared for transition, or built foundational knowledge
-- `项目型 gap`: the candidate worked on independent projects, freelance work, consulting, or hands-on side work
-- `创作型 gap`: the candidate spent the period on sustained creative output such as writing, content creation, or independent publishing
-- `混合型 gap`: the period includes a meaningful mix of study, project work, and non-standard output
-
-For every classified gap or non-standard period, make the analysis explicit about:
-
-- the approximate time range
-- whether the period is a gap, a non-standard experience, or both
-- which classification bucket it belongs to
-- what facts still need confirmation before any stronger packaging is attempted
-
-This issue only covers recognition and classification. Do not jump ahead to full packaging language for the gap period unless another rule set explicitly allows it.
-
-## Gap Packaging Principles
-
-When a gap or non-standard period has already been identified and classified, the next goal is not to erase the gap. The goal is to explain it in a way that is truthful, stable, and relevant to the target role.
-
-Core packaging rules:
-
-- Treat the period as a gap with effective input, not as fake full-time employment
-- Do not invent company names, formal titles, teams, or commercial outcomes
-- Do not package the period as the candidate's main career highlight unless the support is unusually strong
-- Make it clear that the purpose is to reduce negative ambiguity, not to pretend the gap never existed
-
-Use gap packaging only when at least one of these is true:
-
-- the candidate had sustained output during the period
-- the candidate can describe real work, process, and continuity
-- the period produced transferable skills that clearly connect to the target role
-
-Resume-writing rules for packaged gap periods:
-
-- Prefer placing the period under `个人项目`, `补充经历`, or an equivalent non-employment section
-- Use labels such as `个人内容项目`, `独立项目`, or `个人创作项目` when that is what the work actually was
-- Focus on continuity, output, method, and transferable capability
-- If metrics are weak, use output and process clarity instead of invented impact claims
-- Explicitly avoid presenting the period as a formal company job when no formal employer existed
-
-Interview explanation rules for packaged gap periods:
-
-- First acknowledge the period honestly as a gap or non-standard work period
-- Then explain what the candidate was continuously doing during that time
-- Then explain what was produced, learned, or iterated on
-- Finally connect that period back to the target role and why it still matters now
-
-For creative or personal-project gaps, such as writing fiction or running a personal content project:
-
-- frame the period as sustained personal output, not fake institutional employment
-- emphasize continuity, content process, audience feedback, self-management, and transferable skills
-- avoid escalating it into professional scale unless the candidate can support real volume, traction, or monetization
-
-When giving wording suggestions, provide both:
-
-- a safer resume-ready version
-- a safer interview explanation version
-
-Always keep the explanation aligned with the earlier gap classification. Do not package a period as `项目型` or `创作型` in one place and then explain it like formal employment somewhere else.
 
 Supported template families:
 
@@ -342,13 +71,10 @@ Supported template families:
 
 Use the routing and evaluation guidance in [job-families.md](./references/job-families.md).
 
-Current role-specific template coverage:
+When the selected family has a segmented-role reference, apply that reference in addition to the shared family guidance. Current segmented references:
 
-- Product Management: [product-management-template.md](./references/product-management-template.md)
-- Sales: [sales-template.md](./references/sales-template.md)
-- Operations: [operations-template.md](./references/operations-template.md)
-- Backend: [backend-template.md](./references/backend-template.md)
-- Other job families: use the shared workflow plus family routing rules until dedicated templates are added
+- `operations` -> [content-operations-patterns.md](./references/content-operations-patterns.md)
+- `backend` in risk-control / anti-crawler contexts -> [risk-control-backend-patterns.md](./references/risk-control-backend-patterns.md)
 
 ## Dual-Agent Contract
 
@@ -360,10 +86,10 @@ Responsibilities:
 
 - Clarify the candidate's target role, seniority, and strongest stories
 - Select the highest-upside projects instead of treating every line item equally
-- Diagnose what is weak before trying to beautify wording
 - Ask for business context, scope, actions, constraints, tradeoffs, metrics, and lessons
 - Build a candidate project packaging card before writing final bullets
 - Produce stronger resume wording, self-introduction drafts, and interview-ready storylines
+- Explain why each chosen story is ranked as main, support, or gap-explanation material
 
 Agent 1 is allowed to:
 
@@ -371,15 +97,16 @@ Agent 1 is allowed to:
 - Reorder facts to emphasize impact
 - Convert vague participation into precise contribution language when the candidate can explain it
 - Suggest missing support details that must be confirmed
+- Use segmented-role pattern references when they materially change what "strong" looks like
 
 Agent 1 is not allowed to:
 
 - Invent projects, ownership, metrics, or tech the candidate cannot defend
 - Treat team outcomes as personal outcomes without attribution
 - Hide uncertainty; mark unconfirmed items as gaps
-- Treat first-pass packaging as pure rewriting when diagnosis and follow-up are still missing
+- Output a stronger ranking without explaining the reason for that ranking
 
-### 审核官（Review And Calibrate）
+### Agent 2: Review And Calibrate
 
 Responsibilities:
 
@@ -388,39 +115,28 @@ Responsibilities:
 - Judge role-template fit: does this read like a real candidate for the routed job family?
 - Identify interview failure points: what breaks under 3 to 5 follow-up questions?
 - Force a downgrade when the candidate cannot support a stronger version
-- Judge the current level of the wording instead of only labeling it risky
-- Show the safest upgrade path when the material can still be strengthened
+- Challenge ranking logic and explanation quality, not just wording quality
 
-审核官输出结论标签:
+Agent 2 outputs:
 
 - `pass`
 - `pass after supplement`
 - `rewrite required`
 
-For each project, the review output must also produce:
+For each project, Agent 2 must also produce:
 
-- decision label
-- `风险等级`
-- `当前层级`
 - Missing information to collect
-- `不足点`
-- `升级建议`
-- `可守的更优表达`
 - Risk notes
 - Safer downgrade wording when needed
 - Interview pressure points
+- Ranking rationale
 
-Use [review-rubric.md](./references/review-rubric.md) for the shared review checklist. The rubric defines the minimum checks; this section defines the user-visible review output shape.
+Use [review-rubric.md](./references/review-rubric.md) for the shared review checklist.
 
+When the routed case matches a segmented role, Agent 2 should also use the relevant segmented reference:
 
-When the routed family is sales, also apply the sales-specific rules in [sales-template.md](./references/sales-template.md).
-
-When the routed family is product management, also apply the product-specific rules in [product-management-template.md](./references/product-management-template.md).
-
-When the routed family is operations, including self-media operations, also apply the operations-specific rules in [operations-template.md](./references/operations-template.md).
-
-When the routed family is backend or server-side, also apply the backend-specific rules in [backend-template.md](./references/backend-template.md).
-
+- [content-operations-patterns.md](./references/content-operations-patterns.md)
+- [risk-control-backend-patterns.md](./references/risk-control-backend-patterns.md)
 
 ## Project Packaging Card
 
@@ -431,10 +147,6 @@ Use [project-packaging-card-template.md](./assets/project-packaging-card-templat
 Minimum fields:
 
 - Project identity and time range
-- Whether the experience is recent core experience
-- Whether the experience belongs to a gap or non-standard period
-- Narrative position: main story, supporting story, or supplemental highlight
-- Timeline weighting note
 - One-line project definition
 - Business background and goal
 - Candidate responsibility boundary
@@ -442,14 +154,15 @@ Minimum fields:
 - Main challenge and solution
 - Result or value
 - Packaging goal
-- Packaging-plan role
-- Preferred version
+- Packaging explanation layer
 - Missing support
 - Risk notes
 - Resume-ready wording
 - Interview-ready explanation
 
 Do not allow a project into the final resume if the card is still missing basic scope, ownership, or support.
+
+Do not allow a ranked packaging plan into the final answer if it still cannot explain why that ranking is better than alternative story orders.
 
 ## Long-Term Memory
 
@@ -459,6 +172,7 @@ The memory file should track:
 
 - Candidate profile and job-search targets
 - Current approved resume direction
+- Approved ranking logic and current stage blockers
 - Project archive with statuses
 - Approved resume wording and self-introduction
 - Review risks and banned phrasing
@@ -476,36 +190,6 @@ Write only durable information:
 
 Do not dump raw conversation transcripts into memory.
 
-## Flow-State And Memory Link
-
-Stage labels must stay visible in the conversation, but not every stage detail belongs in long-term memory.
-
-Use this boundary:
-
-- `当前阶段 / 当前任务 / 下一步推荐` are session-facing state and should be shown in the conversation
-- reviewed milestone decisions should be written into memory when they will matter next session
-- project-level progress should live in the project packaging card first, then be summarized into memory only when it becomes durable
-
-Persist into memory when the result is stable enough to reuse:
-
-- current approved workflow stage for the candidate
-- whether the next session should resume from stage 1, 2, 3, or 4
-- main narrative decisions, downgraded older experiences, and gap explanations
-- approved wording, banned phrasing, and still-open follow-ups
-
-Do not persist into memory:
-
-- every intermediate status block
-- every temporary packaging guess
-- every back-and-forth clarification that has not yet become a stable conclusion
-
-Session resume rule:
-
-- read memory first
-- detect the last durable workflow stage
-- resume from that stage unless the new user request clearly resets the workflow
-- use project cards to recover project-level context before asking duplicate questions
-
 ## Mock Interview Pattern
 
 Use mock interviews only after at least one reviewed project version exists. Tie every interview back to the current approved narrative, not the original messy resume.
@@ -521,10 +205,16 @@ For every weak answer, record:
 
 - The question
 - What failed
+- Which pressure chain exposed the failure
 - Better answer structure
 - What to study or clarify next
 
 Log these in [interview-error-log-template.md](./assets/interview-error-log-template.md).
+
+When available, use segmented pressure chains instead of generic follow-up logic:
+
+- [content-operations-interview-chain.md](./references/content-operations-interview-chain.md)
+- [risk-control-backend-interview-chain.md](./references/risk-control-backend-interview-chain.md)
 
 ## Quick Reference
 
@@ -537,9 +227,13 @@ If the user says this:
 - "Mock interview me"  
   Use the latest reviewed wording, not raw resume text.
 - "I want stronger packaging"  
-  Increase clarity and ownership only until the review officer can still defend it.
+  Increase clarity and ownership only until Agent 2 can still defend it.
+- "Why is this the main project?"
+  Explain the ranking using role relevance, evidence strength, time recency, and interview survivability.
 - "I don't want to repeat myself next session"  
   Read and update `memory.md`.
+- "Why are we still here?"
+  Refresh the current stage, blocker, and exit condition before continuing.
 
 ## Example
 
@@ -549,16 +243,13 @@ User request:
 
 Apply the skill like this:
 
-1. Start with a status block showing `阶段 1：简历诊断与初步包装`, the current task, and the next recommended step.
-2. Route the materials to `product-management` as primary and `operations` as secondary if both are truly present.
-3. Ask Agent 1 questions that expose business goals, user problems, actions taken, cross-team coordination, and measurable results.
-4. Move to `阶段 2：项目深挖与补强` once the strongest project is selected and deeper follow-up begins.
-5. Fill a project packaging card for the strongest project.
-6. Run the review officer pass to check inflated ownership, missing metrics, weak strategic logic, and the next safe upgrade path.
-7. Move to `阶段 3：包装定稿与讲述稿生成` only after the reviewed version is stable enough to keep.
-8. Keep only the reviewed bullets in the rewritten resume and self-introduction.
-9. Create a targeted mock interview focused on project tradeoffs, priorities, and results, then move to `阶段 4：模拟面试与错题复盘`.
-10. Update `memory.md` with approved wording, weak points, and next drills.
+1. Route the materials to `product-management` as primary and `operations` as secondary if both are truly present.
+2. Ask Agent 1 questions that expose business goals, user problems, actions taken, cross-team coordination, and measurable results.
+3. Fill a project packaging card for the strongest project.
+4. Explain why that project should be the main story instead of another candidate project.
+5. Run Agent 2 review to check inflated ownership, missing metrics, weak strategic logic, and whether the ranking rationale holds up.
+6. Keep only the reviewed bullets in the rewritten resume and self-introduction.
+7. Add a short stage refresh and update `memory.md` with approved wording, weak points, next drills, and current blocker if any.
 
 ## Common Mistakes
 
@@ -566,7 +257,8 @@ Apply the skill like this:
 |---|---|
 | Rewriting the whole resume before clarifying the role | Route the candidate first, then choose the correct template family |
 | Treating every project as equally important | Pick the 1 to 3 projects with the highest upside for the target role |
-| Letting Agent 1's strongest wording go straight into final output | Always run the review officer pass first |
+| Letting Agent 1's strongest wording go straight into final output | Always run Agent 2 review first |
+| Giving a ranked packaging plan with no explanation | Explain why the main story wins on role fit, evidence, and survivability |
 | Saving every conversation detail into memory | Save only durable, reusable state |
 | Over-packaging metrics or ownership | Downgrade to the strongest version the candidate can actually defend |
 | Running mock interviews on raw or unreviewed stories | Interview only against reviewed wording |
@@ -580,6 +272,8 @@ Stop and recalibrate when any of these appear:
 - A metric appears with no source or explanation
 - Ownership grows while the candidate's explanation shrinks
 - The role template changes but the review rubric does not
+- The main-story ranking changes but no one explains why
+- The conversation passes 100+ turns and the current stage is only implied
 - Memory starts storing unverified claims as facts
 
 When a red flag appears, ask for missing facts or downgrade the wording.

--- a/assets/interview-error-log-template.md
+++ b/assets/interview-error-log-template.md
@@ -5,18 +5,17 @@
 - Date:
 - Job family:
 - Interview mode:
+- Pressure chain:
 
 ## Error Item
 
 - Question:
 - Candidate answer summary:
 - What failed:
+- Follow-up breakpoint:
 - Root cause:
 - Better answer structure:
 - Knowledge to review:
 - Project detail to supplement:
 - Priority:
 - Follow-up drill needed:
-- 回写到项目卡片:
-- 必须写回 memory:
-- Memory status: `已确认 / 待补充 / 高风险`

--- a/assets/memory-template.md
+++ b/assets/memory-template.md
@@ -18,13 +18,15 @@
 - Target compensation:
 - Preferred company types:
 - Current search stage:
+- Current stage blocker:
+- Next stage entry condition:
 
 ## 3. Resume Status
 
 - Current main resume version:
 - Current positioning summary:
-- Current workflow stage:
-- Resume from stage:
+- Approved main-story ranking:
+- Approved support-story ranking:
 - Main resume weaknesses:
 - Completed optimizations:
 - Remaining weak areas:
@@ -37,6 +39,7 @@
 - One-line definition:
 - Responsibility boundary:
 - Current packaging angle:
+- Current story placement:
 - Approved highlights:
 - Missing support:
 - Risk level:
@@ -46,7 +49,6 @@
 - Approved self-introduction:
 - Approved resume bullets:
 - Approved interview storylines:
-- Status: `已确认 / 待补充 / 高风险`
 
 ## 6. Review Risk Notes
 
@@ -54,31 +56,12 @@
 - Banned or downgraded phrasing:
 - Data pending verification:
 - Likely follow-up pressure points:
-
-## Memory Writeback Rules
-
-### 必须写回 memory
-
-- 已通过审核并准备复用的表述
-- 被判定为高风险、以后不应重复使用的表述
-- 待补充但下次必须继续追问的关键事实、指标或解释缺口
-- 在模拟面试中重复暴露的问题
-
-### 不应写回 memory
-
-- 未经确认的包装尝试
-- 一次性闲聊内容
-- 还没有经过审核官确认的强表述
-
-### 写回状态
-
-- `已确认`: later sessions can reuse directly
-- `待补充`: keep as follow-up work, not approved wording
-- `高风险`: keep as warning or banned phrase
+- Ranking logic that has been approved:
 
 ## 7. Mock Interview Notes
 
 - Recent interview mode:
+- Recent pressure chain:
 - Strong answer areas:
 - Weak answer areas:
 - Recurring communication issues:

--- a/assets/project-packaging-card-template.md
+++ b/assets/project-packaging-card-template.md
@@ -7,11 +7,6 @@
 - Company or business line:
 - Job family:
 - Tech or work context:
-- Is recent core experience:
-- Gap or non-standard period:
-- Narrative position:
-- Timeline weighting note:
-- Resume from stage:
 
 ## One-Line Definition
 
@@ -57,8 +52,8 @@
 ## Packaging Goal
 
 - What capability this project should signal:
-- Packaging-plan role:
-- Preferred version:
+- Why this should be a main story, support story, or gap explanation:
+- Why this ordering is better than competing stories:
 
 ## Missing Support
 
@@ -77,6 +72,13 @@
 - Bullet 1:
 - Bullet 2:
 
+## Packaging Explanation Layer
+
+- Role-fit explanation:
+- Ranking rationale:
+- Evidence ceiling:
+- Why stronger wording would become unsafe:
+
 ## Interview-Ready Story
 
 - Background:
@@ -84,6 +86,7 @@
 - Challenge:
 - Solution:
 - Result:
+- Likely pressure follow-up chain:
 
 ## Review Output
 
@@ -92,7 +95,4 @@
 - Top review concerns:
 - Required supplements:
 - Downgrade wording if needed:
-- Packaging-plan verdict:
-- Memory writeback status:
-- Memory writeback note:
-- 回写到项目卡片:
+- Stage blocker if not ready to advance:

--- a/docs/plans/2026-03-29-issues-67-70-combined-skill-upgrade.md
+++ b/docs/plans/2026-03-29-issues-67-70-combined-skill-upgrade.md
@@ -1,0 +1,96 @@
+# Issues #67-#70 Combined Skill Upgrade Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Upgrade the skill so it can better explain packaging choices, stay legible in very long conversations, use segmented role pattern libraries for content-operations and risk-control backend, and run stronger pressure interview chains for those two tracks.
+
+**Architecture:** Keep the shared dual-agent workflow as the backbone. Add a new segmented-role reference layer for excellent resume patterns and role-specific interview chains, extend the main skill with stronger explanation and stage-refresh rules, and update shared templates and validation scenarios so the new behavior is testable instead of implied.
+
+**Tech Stack:** Markdown skill docs, governance references, validation scenarios, repository check script, GitHub issue/PR workflow.
+
+### Task 1: Prepare branch and baseline
+
+**Files:**
+- Create: none
+- Modify: none
+- Test: `./scripts/run_checks.sh`
+
+**Step 1:** Work on branch `codex/67-70-combined-skill-upgrade` from `main`.
+
+**Step 2:** Run `./scripts/run_checks.sh` before editing to confirm baseline state.
+
+**Step 3:** Record any pre-existing failures or unrelated untracked files.
+
+### Task 2: Add segmented role pattern references
+
+**Files:**
+- Create: `references/content-operations-patterns.md`
+- Create: `references/risk-control-backend-patterns.md`
+
+**Step 1:** Write a content-operations pattern library that captures strong signals, project storytelling shapes, risky expressions, and reviewer usage guidance.
+
+**Step 2:** Write a risk-control-backend pattern library covering attack-defense chains, platform value expression, risky metrics, and reviewer usage guidance.
+
+**Step 3:** Keep both files as abstracted pattern references, not raw example resumes.
+
+### Task 3: Add role-specific pressure interview chains
+
+**Files:**
+- Create: `references/content-operations-interview-chain.md`
+- Create: `references/risk-control-backend-interview-chain.md`
+
+**Step 1:** Define multi-turn pressure chains for content-operations and self-media operations.
+
+**Step 2:** Define multi-turn pressure chains for risk-control and anti-crawler backend.
+
+**Step 3:** Include trigger points, likely weak answers, and correction directions so the chains are reusable by both reviewer and interviewer roles.
+
+### Task 4: Upgrade the shared skill rules
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `references/job-families.md`
+- Modify: `references/review-rubric.md`
+
+**Step 1:** Add packaging explanation and ranking-justification requirements to the main workflow and project output expectations.
+
+**Step 2:** Add long-conversation stage refresh requirements with entry conditions, exit conditions, and current blockers.
+
+**Step 3:** Link content-operations and risk-control backend to the new role-specific pattern libraries and interview chains.
+
+**Step 4:** Extend family routing notes for self-media operations and risk-control / anti-crawler backend sub-signals.
+
+**Step 5:** Extend the review rubric so role-specific calibration and explanation quality become explicit review checks.
+
+### Task 5: Upgrade shared templates
+
+**Files:**
+- Modify: `assets/project-packaging-card-template.md`
+- Modify: `assets/memory-template.md`
+- Modify: `assets/interview-error-log-template.md`
+
+**Step 1:** Add explicit fields for packaging rationale, narrative ranking, and role-fit explanation to the project card.
+
+**Step 2:** Add durable memory slots for approved ranking logic, current stage blockers, and segmented-role focus.
+
+**Step 3:** Extend the interview error log so pressure-chain failures and follow-up breakpoints can be tracked.
+
+### Task 6: Add validation coverage
+
+**Files:**
+- Modify: `references/validation-scenarios.md`
+
+**Step 1:** Add scenarios for long-dialog stage refresh, packaging explanation, content-operations specialization, and risk-control backend specialization.
+
+**Step 2:** Make each scenario define expected routing, required explanation behavior, and at least one over-packaging or interview-pressure risk.
+
+### Task 7: Verify and prepare PR
+
+**Files:**
+- Test: `./scripts/run_checks.sh`
+
+**Step 1:** Run `./scripts/run_checks.sh`.
+
+**Step 2:** Review diffs for issue-scope drift and README-first violations.
+
+**Step 3:** Summarize how the PR addresses `#67`, `#68`, `#69`, and `#70`, including risk changes and validation evidence.

--- a/references/content-operations-interview-chain.md
+++ b/references/content-operations-interview-chain.md
@@ -1,0 +1,57 @@
+# Content Operations Pressure Interview Chain
+
+Use this chain after at least one content-operations or self-media-operations project has passed review.
+
+## Chain A: Topic Selection To Feedback Loop
+
+1. What user or business problem was this content project trying to solve?
+2. How did you decide what topics or content directions to prioritize?
+3. What evidence told you that the direction was working or not working?
+4. Give one iteration you made after negative feedback or weak data.
+5. If the same metric improved but the content quality complaints increased, what would you do?
+
+Likely failure points:
+
+- cannot connect content actions to a business objective
+- talks about intuition only, with no selection mechanism
+- describes results without saying what changed in the next round
+
+Correction direction:
+
+- rebuild answer as objective -> mechanism -> feedback -> iteration -> tradeoff
+
+## Chain B: Multi-Platform Distribution
+
+1. Which platforms mattered most and why?
+2. What was different in your operating approach across those platforms?
+3. Which metric mattered most on each platform?
+4. Tell me about one platform where the same content idea failed.
+5. What did that failure teach you about audience or channel mismatch?
+
+Likely failure points:
+
+- same answer for every platform
+- only knows posting schedule, not audience difference
+- treats distribution as pure execution with no strategy
+
+Correction direction:
+
+- force platform-by-platform comparison with audience, format, and metric differences
+
+## Chain C: Personal Content Or Gap Explanation
+
+1. Why should I treat this period as relevant rather than just a gap?
+2. What stable output or capability did you build during that time?
+3. Why is this not strong enough to be the main project on your resume?
+4. If I ask for one representative content cycle, can you walk through it end to end?
+5. What operating habit from that period would still transfer to a formal content role?
+
+Likely failure points:
+
+- says "I kept writing" but cannot name outputs, cadence, or learning
+- overstates personal creation as if it were a staffed business role
+- cannot explain transferability
+
+Correction direction:
+
+- downgrade to gap explanation unless stable output, process, and role relevance are defendable

--- a/references/content-operations-patterns.md
+++ b/references/content-operations-patterns.md
@@ -1,0 +1,92 @@
+# Content Operations And Self-Media Patterns
+
+Use this file when the routed family is `operations` and the candidate reads like content operations, editorial operations, creator operations, or self-media operations.
+
+## What Strong Content-Operations Resumes Usually Signal
+
+- Can explain the content objective, not just the execution list
+- Can connect topic selection, distribution, iteration, and feedback loop into one operating chain
+- Can describe platform differences instead of treating every channel the same
+- Can separate content production work from traffic, growth, and conversion work
+- Can show repeatable mechanism building, not just one-off good ideas
+
+## High-Value Story Shapes
+
+### Shape 1: Topic Selection And Content Mechanism
+
+Use when the candidate built or improved a topic-selection process.
+
+Expected signal:
+
+- how topics were sourced
+- how priorities were set
+- how user feedback changed the next round
+- what quality or efficiency improved
+
+### Shape 2: Distribution And Channel Operations
+
+Use when the candidate ran multi-platform distribution or channel operations.
+
+Expected signal:
+
+- platform-specific strategy
+- target audience differences
+- posting or distribution rhythm
+- feedback loop and optimization actions
+
+### Shape 3: Growth And Retention Linkage
+
+Use when the candidate connects content to user growth, retention, or conversion.
+
+Expected signal:
+
+- funnel location
+- which metric moved
+- why content was the driver
+- what tradeoff was accepted
+
+### Shape 4: Personal Content Project As A Support Story
+
+Use when the candidate has creator work, a personal account, or a long content gap period.
+
+Expected signal:
+
+- whether this is a main project, side support story, or gap explanation only
+- stable output cadence or concrete body of work
+- what capability was kept warm or improved
+- why this should not be overstated as a formal business role
+
+## Packaging Rules
+
+- Explain why the project deserves main-story, secondary-story, or gap-explanation placement.
+- Prefer mechanism language over vague creativity language.
+- Keep platform claims specific: topic style, distribution habit, audience difference, and feedback source.
+- If metrics lack baseline, attribution, or ownership, downgrade from result claim to observed trend or supporting evidence.
+- Personal content work must never be written like formal employment unless the candidate can defend the commercial and organizational reality.
+
+## Reviewer Focus
+
+Agent 2 should challenge:
+
+- content work that lists actions but cannot name the objective
+- metrics that cannot explain baseline, period, or personal contribution
+- creator or gap-period work that is presented as if it were equivalent to a staffed operating role
+- stories with strong output but weak mechanism
+- packaging that overuses campus highlights while recent work remains under-explained
+
+## Strong Explanation Angles
+
+When the packaging coach explains the plan, prioritize:
+
+- why this story is the best proof of operating capability
+- why a project is positioned as main story, support story, or gap explanation
+- which platform or content loop capability the interviewer should notice
+- what evidence is still weak and therefore capped
+
+## High-Risk Expressions
+
+- "负责账号增长" with no channel, mechanism, or metric frame
+- "独立完成内容策略" when the role was mainly execution support
+- "全网爆款" without stable standard or attributable action
+- "自媒体创业" when the candidate really means sustained personal creation practice
+- "提升转化" without saying where in the funnel and how measured

--- a/references/job-families.md
+++ b/references/job-families.md
@@ -22,7 +22,12 @@ Signals:
 
 Bias toward this family when the resume reads like systems, services, data flow, reliability, or infrastructure-heavy delivery.
 
-When this family is selected, also apply [backend-template.md](./backend-template.md).
+Sub-signals worth routing explicitly:
+
+- risk control, anti-crawler, anti-abuse, decision engine, device fingerprint, strategy platform
+- confrontation-heavy delivery where attacker behavior, interception quality, false positives, or strategy iteration are central
+
+When these sub-signals dominate, keep the primary family as `backend`, but apply the segmented guidance in [risk-control-backend-patterns.md](./risk-control-backend-patterns.md) and [risk-control-backend-interview-chain.md](./risk-control-backend-interview-chain.md).
 
 ### Frontend
 
@@ -67,15 +72,11 @@ Signals:
 
 - requirement design, roadmap, user problem, feature spec, cross-team delivery, KPI, PRD
 
-When this family is selected, also apply [product-management-template.md](./product-management-template.md).
-
 ### Sales
 
 Signals:
 
 - pipeline, conversion, customer acquisition, contract, revenue, upsell, key account
-
-When this family is selected, also apply [sales-template.md](./sales-template.md).
 
 ### Operations / Self-Media Operations
 
@@ -83,7 +84,12 @@ Signals:
 
 - growth, activity planning, content strategy, retention, funnel, traffic, self-media, followers
 
-When this family is selected, also apply [operations-template.md](./operations-template.md).
+Sub-signals worth routing explicitly:
+
+- content operations, editorial operations, creator operations, platform distribution, topic planning
+- gap periods supported by sustained personal creation or account operations
+
+When these sub-signals dominate, apply the segmented guidance in [content-operations-patterns.md](./content-operations-patterns.md) and [content-operations-interview-chain.md](./content-operations-interview-chain.md).
 
 ## Conflict Handling
 
@@ -91,3 +97,4 @@ When this family is selected, also apply [operations-template.md](./operations-t
 - If the resume mixes product and operations, pick `product-management` only when ownership over problem definition and solution design is clear.
 - If the resume mixes sales and operations, prefer `sales` only when quota, conversion, or deal-making is central.
 - If the user explicitly states a target role, respect it unless the materials clearly contradict it. In that case, note the mismatch and ask once for confirmation.
+- If the candidate looks like generic backend or generic operations at first, but the strongest project logic depends on segmented-role signals, keep the base family and activate the corresponding segmented reference files.

--- a/references/review-rubric.md
+++ b/references/review-rubric.md
@@ -1,6 +1,6 @@
 # Review Rubric
 
-审核官在任何表述定稿前都要先应用这套共享 rubric。
+Agent 2 uses this shared rubric before anything becomes final wording.
 
 ## Decision Labels
 
@@ -41,6 +41,8 @@ Reject wording the candidate probably cannot explain under follow-up:
 
 Check whether the project now sounds like a real candidate for the routed job family.
 
+If a segmented role reference exists for the routed case, check whether the wording also sounds like a real candidate for that sub-direction rather than a generic family member.
+
 ### 5. Result Credibility
 
 Challenge:
@@ -52,6 +54,22 @@ Challenge:
 ### 6. Interview Survivability
 
 Ask whether the story can survive 3 to 5 follow-up questions. If not, downgrade or request more support.
+
+### 7. Packaging Explanation Quality
+
+Check whether the packaging coach can explain:
+
+- why this project is ranked as main story, support story, or gap explanation
+- why the chosen wording ceiling matches the available evidence
+- why this packaging is a better fit for the routed role than alternative stories
+
+### 8. Long-Conversation Stage Legibility
+
+In long dialogues, check whether the current stage remains explicit enough for the user to understand:
+
+- why the process is still in this stage
+- what is blocking the next stage
+- what condition would allow the stage to exit
 
 ## Risk Levels
 
@@ -66,38 +84,9 @@ For each project card, output:
 
 - decision label
 - risk level
-- 当前层级
 - top 3 risks
-- 不足点
 - missing info to collect
-- 升级建议
-- 可守的更优表达
 - downgrade wording if needed
 - likely interview pressure points
-
-## 写回条件
-
-Review output must not stay isolated from long-term memory. Use these rules:
-
-### 必须写回 memory
-
-- wording that is `pass` and becomes approved resume wording
-- wording downgraded because it is too risky and should not be reused later
-- metrics or claims marked `data pending verification`
-- repeated interview pressure points that will likely return in future sessions
-
-### 不应写回 memory
-
-- speculative wording that the candidate has not confirmed
-- early brainstorming angles that were not approved
-- one-off conversational details with no long-term reuse value
-
-### 状态边界
-
-When review results are written back, keep the status explicit:
-
-- `已确认`: safe to reuse in later sessions
-- `待补充`: direction is useful but support is still missing
-- `高风险`: keep as a warning or banned phrase, not approved wording
-
-If a project stays at `rewrite required`, write the risk to memory but do not write the wording as approved output.
+- ranking rationale
+- stage blocker if the dialogue has not advanced

--- a/references/risk-control-backend-interview-chain.md
+++ b/references/risk-control-backend-interview-chain.md
@@ -1,0 +1,57 @@
+# Risk-Control Backend Pressure Interview Chain
+
+Use this chain after at least one risk-control or anti-crawler backend project has passed review.
+
+## Chain A: Risk Problem And Decision Chain
+
+1. What exact risk or abuse problem was this project trying to control?
+2. Where in the decision chain did your work sit?
+3. What signals, rules, or services were upstream and downstream from you?
+4. What tradeoff did your team manage between interception strength and false positives?
+5. How would the business feel the change if your module failed for one day?
+
+Likely failure points:
+
+- generic backend answer with no risk context
+- cannot place their module in the strategy chain
+- cannot discuss tradeoff or failure consequence
+
+Correction direction:
+
+- rebuild answer as risk scene -> chain position -> contribution -> tradeoff -> business effect
+
+## Chain B: Attack-Defense Iteration
+
+1. What attacker behavior or evasion pattern forced this iteration?
+2. How did you discover or confirm that pattern?
+3. What changed in strategy, service logic, or tooling because of it?
+4. How did you know the response helped without causing too much mis-kill?
+5. What happened in the next confrontation round?
+
+Likely failure points:
+
+- cannot describe an adversary model
+- treats one rule change as the whole story
+- no monitoring or quality evaluation loop
+
+Correction direction:
+
+- force a time-sequenced narrative: adversary move -> detection -> response -> evaluation -> next adaptation
+
+## Chain C: Platform Or Tooling Value
+
+1. Who used the platform or tool you built?
+2. What manual or fragmented process existed before?
+3. What part of the workflow became faster, safer, or easier to govern?
+4. Which result belongs to you, and which belongs to the wider team or operation?
+5. If the business metric is hard to expose, what safer evidence can you provide?
+
+Likely failure points:
+
+- overclaims platform impact
+- cannot separate team and personal contribution
+- uses vague efficiency language
+
+Correction direction:
+
+- downgrade to workflow, observability, or governance value when direct risk-yield evidence is weak

--- a/references/risk-control-backend-patterns.md
+++ b/references/risk-control-backend-patterns.md
@@ -1,0 +1,92 @@
+# Risk-Control And Anti-Crawler Backend Patterns
+
+Use this file when the routed family is `backend` and the candidate reads like risk control, anti-crawler, device intelligence, strategy platform, or confrontation-heavy backend.
+
+## What Strong Risk-Control Backend Resumes Usually Signal
+
+- Can define the risk problem, attack pattern, or abuse scenario in business terms
+- Can explain the strategy chain, not just the service module
+- Can connect technical action to risk yield, interception quality, or operational efficiency
+- Can discuss tradeoffs between recall, precision, cost, latency, and false positive risk
+- Can describe iterative confrontation instead of presenting one-time rule changes as final victory
+
+## High-Value Story Shapes
+
+### Shape 1: Strategy Engine Or Rule Platform
+
+Use when the candidate built or improved a strategy engine, rule platform, or decision chain.
+
+Expected signal:
+
+- what decision flow existed
+- what bottleneck or risk gap existed
+- what was changed in the engine or rule pipeline
+- how the change improved iteration speed, observability, or control
+
+### Shape 2: Device Or Identity Risk Recognition
+
+Use when the candidate worked on device fingerprinting, identity association, or recognition.
+
+Expected signal:
+
+- what risk signal or pattern was being captured
+- what evasion pressure existed
+- how recognition quality was improved
+- where the edge cases or mis-kill risk lived
+
+### Shape 3: Attack-Defense Iteration
+
+Use when the project involved anti-crawler, abuse prevention, or iterative adversarial defense.
+
+Expected signal:
+
+- attacker behavior or evolution
+- defender response cycle
+- what instrumentation or strategy updates were introduced
+- how effectiveness was observed over time
+
+### Shape 4: Risk Platform Value Story
+
+Use when the candidate enabled other teams through backend infrastructure or tooling.
+
+Expected signal:
+
+- who used the platform
+- what manual or fragmented process was replaced
+- what efficiency or governance benefit followed
+- what remains shared team credit versus individual contribution
+
+## Packaging Rules
+
+- Prefer attack-defense chain language over generic "high concurrency" or "large-scale architecture" claims.
+- Tie every strong metric to a denominator, period, and ownership boundary.
+- If business risk reduction cannot be quantified safely, describe the defended link, operational effect, or decision quality instead of inventing ROI.
+- AI-assisted efficiency stories must state the bounded use case and human control line.
+- Do not let shared team platform outcomes collapse into personal architecture ownership.
+
+## Reviewer Focus
+
+Agent 2 should challenge:
+
+- "负责整体风控架构" when the candidate owned only one chain or module
+- interception or risk metrics with no baseline, sample window, or false-positive discussion
+- anti-crawler stories that omit the adversary model
+- backend bullets that sound generic and lose the risk-control context
+- AI tooling stories that sound like autonomous decision-making when they were assistive only
+
+## Strong Explanation Angles
+
+When the packaging coach explains the plan, prioritize:
+
+- why this project best proves risk-control backend judgment rather than generic backend delivery
+- how the chosen main story shows strategy, iteration, and tradeoff handling
+- what evidence limits the wording ceiling
+- why some achievements stay as support bullets rather than main narrative
+
+## High-Risk Expressions
+
+- "搭建完整风控体系" without full-scope ownership
+- "日均拦截 xx 万风险" without denominator, quality, or contribution split
+- "设计核心反爬架构" when contribution was strategy iteration or module implementation
+- "AI 自动识别风险" when the actual role was decision support or analyst acceleration
+- "零事故" as a vanity signal with no relevance to risk-control capability

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -20,43 +20,13 @@ Prompt:
 
 Expected behavior:
 
-- begin with a visible status block
-- show `当前阶段`, `当前任务`, and `下一步推荐`
 - route to backend
 - select strongest projects
 - create project packaging card
 - ask for missing scope, challenge, and metrics
-- review output before final wording instead of jumping straight to final bullets
+- review output before final wording
 
-## Scenario 2: Flow Visibility Before Rewriting
-
-Prompt:
-
-`Use $job-copilot-skill to package my resume for product roles. I want a stronger version quickly.`
-
-Expected behavior:
-
-- start in `阶段 1：简历诊断与初步包装`
-- make the current task explicit before any rewritten output
-- recommend the next step, such as clarifying the strongest project or filling missing ownership details
-- avoid pretending that interview training or final packaging is already in progress
-- avoid skipping directly to a full final resume before diagnosis and follow-up
-
-## Scenario 3: Force Status Block Before Fast Rewrite
-
-Prompt:
-
-`Use $job-copilot-skill to rewrite my resume quickly for product roles. Give me a strong version directly.`
-
-Expected behavior:
-
-- still begin with a status block
-- still make the current stage explicit
-- state the current task before giving any rewritten content
-- recommend the next step if diagnosis or follow-up is still needed
-- avoid pretending the flow is already in final packaging or mock interview mode
-
-## Scenario 4: Mixed Product And Operations Background
+## Scenario 2: Mixed Product And Operations Background
 
 Prompt:
 
@@ -69,7 +39,7 @@ Expected behavior:
 - tailor deep-dive questions to business goals, cross-team work, and measurable outcomes
 - avoid backend-style review criteria
 
-## Scenario 5: Repeat Session With Memory
+## Scenario 3: Repeat Session With Memory
 
 Prompt:
 
@@ -82,311 +52,58 @@ Expected behavior:
 - focus on stored weak points and error log
 - update memory after the mock interview
 
-## Scenario 6: Self-Media Operations Ownership Check
+## Scenario 4: Packaging Explanation And Ranking
 
 Prompt:
 
-`Use $job-copilot-skill to package my self-media operations experience. The account grew from 5k to 40k followers, but I only owned topic planning and part of the weekly review.`
+`Use $job-copilot-skill to improve my resume for product roles. I have three projects and I want to know why one should be my main story and the others should be secondary.`
 
 Expected behavior:
 
-- route to operations
-- apply operations-specific deep-dive questions
-- distinguish account-level growth from the candidate's direct actions
-- ask for downstream metrics or iteration detail instead of over-indexing on follower count
-- downgrade strategy ownership if the candidate cannot support full-account responsibility
+- route to product management
+- select one main story and explain why
+- explain why the other projects are support stories instead of main stories
+- reference role relevance, time recency, result strength, explainability, or risk boundary
+- avoid outputting a ranking with no justification
 
-## Scenario 7: Sales Conversion Attribution Check
+## Scenario 5: Long Dialogue Stage Refresh
 
 Prompt:
 
-`Use $job-copilot-skill to strengthen my sales story. Our team signed several large clients last quarter, and I want the resume to sound more aggressive.`
+`Use $job-copilot-skill to continue our long resume rewrite. We have already talked for a long time and I am not sure why we are still here.`
 
 Expected behavior:
 
-- route to sales
-- ask for customer segment, sales stage ownership, and attributable metrics
-- separate team revenue from personal contribution
-- challenge unsupported quota or close-rate language
-- produce safer downgrade wording if the candidate cannot prove full deal ownership
+- restate the current stage explicitly
+- explain why the process is still in that stage
+- name the blocker or missing information
+- state the condition required to move to the next stage
+- keep the refresh concise rather than turning it into a full report
 
-## Scenario 8: Backend Over-Packaging Guardrail
+## Scenario 6: Content Operations And Self-Media Specialization
 
 Prompt:
 
-`Use $job-copilot-skill to package my backend project more aggressively. I used Redis and MQ, but I only implemented part of the order service and I am not sure how to describe ownership.`
+`Use $job-copilot-skill to help me target content operations roles. I have formal operations experience plus a year of running my own content account during a gap.`
 
 Expected behavior:
 
-- route to backend
-- use backend-specific deep-dive questions
-- separate actual ownership from team-level system design
-- avoid inventing architecture authority
-- produce downgrade advice if the candidate cannot defend a stronger version
+- route to operations with content-operations specialization
+- separate formal role experience from personal content or gap-period material
+- explain whether the personal content period is a main story, support story, or gap explanation
+- challenge metrics that lack baseline, period, or attribution
+- use content-operations-style follow-up questions instead of generic operations questions
 
-## Scenario 9: Distant Campus Experience Should Not Override Recent Work
+## Scenario 7: Risk-Control Backend Specialization
 
 Prompt:
 
-`Today is 2026-03-29. Use $job-copilot-skill to help me target content operations roles. I have a strong campus self-media project from 2021, but I also have store operations work from 2024 and advertising operations work from 2025.`
+`Use $job-copilot-skill to improve my resume for risk-control backend roles. My background includes anti-crawler strategy services and device recognition work.`
 
 Expected behavior:
 
-- recognize the case as a social-hire timeline, not a campus-first timeline
-- explicitly anchor the judgment to the current date or current hiring moment
-- compare the 2021 campus experience against the 2024-2025 work experience instead of using vague language
-- evaluate recent 1 to 3 year experience before choosing the main narrative
-- avoid automatically making the older campus project the main story just because it sounds stronger
-- keep the campus project only as the main narrative if the newer work is clearly too weak or too unrelated
-- explain which experience is the current main narrative and which is supporting evidence
-- explain why the 2021 experience is downgraded or kept at the 2026-03-29 time point
-
-## Scenario 10: Gap And Non-Standard Experience Must Be Classified First
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to review my resume. I have a 9-month period in 2025 where I was not in a fixed company. During that time I prepared for a role transition, wrote online fiction, and ran a small personal content account.`
-
-Expected behavior:
-
-- recognize this as a gap or non-standard experience period instead of ignoring it
-- avoid converting the period directly into formal employment
-- classify the period as learning, project, creative, mixed, or explain why the current information is still insufficient
-- ask for time range, output, and continuity details if the classification is still ambiguous
-- make it clear that recognition comes before packaging
-
-## Scenario 11: Gap Packaging Should Reduce Ambiguity Without Faking Employment
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to help me package a 2025 gap period. I was not in a fixed company, but I spent that time writing online fiction and running a personal content account. I want the gap to look more reasonable on my resume and in interviews.`
-
-Expected behavior:
-
-- acknowledge that this is still a gap or non-standard period
-- avoid converting it directly into formal employment
-- suggest a safer resume placement such as personal project or supplemental experience
-- suggest an interview explanation that first admits the gap, then explains sustained work and transferable skills
-- avoid fake companies, fake titles, or unsupported commercial scale
-
-## Scenario 12: Packaging Must Diagnose Before Final Rewriting
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to rewrite my resume for product operations. My bullets feel ordinary, and I want a stronger version quickly.`
-
-Expected behavior:
-
-- start with the required status block
-- stay in `阶段 1：简历诊断与初步包装` if the skill is still assessing the material
-- identify which 1 to 3 experiences are the best packaging targets before rewriting
-- explain the current weakness or missing support in those experiences
-- ask for missing scope, ownership, baseline, or result details before treating any rewritten version as final
-- if a draft is provided, mark it as provisional rather than final
-- avoid jumping straight to a polished full rewrite with no diagnosis
-
-## Scenario 13: Review Officer Must Provide Upgrade Guidance
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package my operations project aggressively and then run the review pass. I improved activity conversion, but I am not fully sure whether the ownership and metrics are strong enough.`
-
-Expected behavior:
-
-- the review pass should still do risk control
-- the review pass should explicitly judge the current level instead of only saying the wording is risky
-- the review pass should identify the main shortcomings
-- the review pass should explain how to move the wording up one level safely
-- the review pass should provide a safer stronger expression the candidate can still defend
-- the review pass should avoid generic praise or generic caution with no actionable next step
-
-## Scenario 14: Packaging Output Must Show Problem Direction Result And Risk
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package my strongest operations project into a stronger version for resume use, but keep the explanation easy to follow.`
-
-Expected behavior:
-
-- stay in the packaging flow instead of collapsing directly into one final bullet
-- show what the current weakness is
-- show the recommended packaging direction
-- show a stronger draft result
-- show what still needs supplement or what risks remain
-- keep the output conversational rather than turning it into a long report
-
-## Scenario 15: Packaging Should Use The High-Quality Signal Library
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to make my resume look stronger for operations, but do not just beautify the wording. I want it to read like a genuinely strong operations candidate.`
-
-Expected behavior:
-
-- use role-specific high-quality signals instead of generic polishing
-- choose stronger capability angles that match operations
-- reflect a stronger expression structure or result strategy
-- make it clear what kind of strong-candidate signal the packaging is trying to surface
-- avoid treating the signal library like a raw template dump
-
-## Scenario 18: Follow-Up Session Should Resume From Stored Progress
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill with my existing memory to continue from the last session. We already finished project deep-dive, selected the main narrative, and only need reviewed wording plus the next interview drill.`
-
-Expected behavior:
-
-- read memory first
-- identify the stored workflow stage and resume from it
-- avoid replaying full intake and routing if those are already settled
-- use stored project-card context and durable memory conclusions to continue the work
-- only reset to an earlier stage if the new request clearly changes the target role or candidate story
-
-## Scenario 16: Project Card Must Support Timeline And Narrative Sorting
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package my resume. I have a campus content project from 2021, store operations work from 2024, and a 2025 gap period where I ran a personal content account.`
-
-Expected behavior:
-
-- when creating project cards, mark which experience is recent core work
-- mark the 2025 content account period as gap or non-standard experience rather than formal employment
-- show which card is the main narrative, which is supporting evidence, and which is only a supplemental highlight
-- include an explicit timeline weighting note instead of relying on unstated judgment
-
-## Scenario 17: Packaging Plan Must Appear Before Stable Final Wording
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package my real resume for internet roles. Before final rewriting, first give me a packaging plan with the main direction, the narrative order, per-experience packaging goals, facts that must be supplemented, claims that must be downgraded, and a safer versus stronger version recommendation.`
-
-Expected behavior:
-
-- begin with the required status block
-- stay in diagnosis or planning mode rather than pretending final wording is already settled
-- produce a packaging-plan layer before stable final wording
-- make the main packaging direction explicit
-- distinguish main narrative, supporting narrative, and lower-priority highlights
-- state what still needs support
-- state what must be downgraded
-- provide a safer and stronger route, or explain why only one route is advisable
-- avoid jumping directly from diagnosis to polished final bullets
-
-## Scenario 19: Real Resume Must Produce A Decomposition Layer Before Stable Packaging
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package my real resume for internet roles. Before rewriting, first tell me how you understand the timeline, the current main narrative, the supporting narrative, the supplemental highlights, any gap or non-standard periods, and the main interview pressure points.`
-
-Expected behavior:
-
-- begin with the required status block
-- stay in diagnosis or early deep-dive rather than pretending final packaging is already complete
-- produce a decomposition layer before stable packaging
-- make the current analysis date or hiring moment explicit when timeline matters
-- distinguish `主叙事 / 辅助叙事 / 补充亮点`
-- identify gap or non-standard periods instead of skipping them
-- surface main ownership, metric-caliber, or explainability risks
-- recommend the next deep-dive priorities before moving into final rewrite
-- avoid jumping directly from intake to polished final bullets
-
-## Scenario 20: Fine-Grained Content-Operations Template Should Change The Packaging Path
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package a real content-operations resume with campus self-media, personal creation, and generic operations work.`
-
-Expected behavior:
-
-- route to operations, then narrow into the content-operations or self-media template
-- use content-specific strong signals and expression structure
-- treat personal creation as a content-project-style signal when support exists
-- keep the review focused on audience, topic logic, distribution, iteration, and attribution
-- avoid flattening the case into generic operations wording
-
-## Scenario 21: Fine-Grained Risk-Control Backend Template Should Change The Packaging Path
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package a backend resume with anti-crawl, device fingerprint, and real-time risk decisioning systems.`
-
-Expected behavior:
-
-- keep backend as the main route, then narrow into the risk-control-backend template
-- use subdomain-specific strong signals and result strategy
-- focus the review on decision path, latency, availability, ownership, and risk tradeoffs
-- keep AI tooling, architecture authority, and large-scale metrics as high-pressure review points
-- avoid flattening the case into generic backend wording
-
-## Scenario 22: Personal Creation Period Must Produce Safe Content-Role Packaging
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package a content-operations resume where a 2025 gap period was spent writing fiction and running a personal content account.`
-
-Expected behavior:
-
-- narrow from broad operations into the content-operations or self-media template
-- identify the 2025 period as a gap-period content project or non-standard content experience
-- provide a safe resume placement instead of rewriting it as fixed-company employment
-- give explicit packaging boundaries and interview explanation guidance
-- connect the period to durable content capability such as topic choice, output continuity, feedback loops, or audience understanding
-- avoid treating the period as either empty gap or fabricated formal work
-
-## Scenario 23: Risk-Control Backend Must Tighten Ownership Review On Strong Claims
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package a backend resume with anti-crawl, device fingerprint, architecture wording, AI tooling, and platform-level metrics.`
-
-Expected behavior:
-
-- keep backend as the main route, then narrow into the risk-control-backend template
-- make the result-expression strategy explicit instead of accepting only big claims
-- force clear boundaries for `架构师职责边界`
-- force clear boundaries for `AI 工具真实 ownership`
-- distinguish `团队成果与个人成果区分`
-- use a more specific risk-control-backend mock interview chain instead of generic backend questions
-
-## Scenario 24: Review And Mock-Interview Results Must Produce Explicit Memory Writeback Decisions
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to review a packaged project, mark one bullet as approved, one metric as high-risk, and one mock-interview answer as weak. Then tell me what must be written back to memory or the project card.`
-
-Expected behavior:
-
-- make the writeback decision explicit instead of leaving it implicit
-- include `必须写回 memory` and `不应写回 memory` boundaries
-- mark the outputs with `已确认 / 待补充 / 高风险`
-- decide whether the mock-interview failure should also be written back to the project card
-- avoid storing unconfirmed wording as approved long-term memory
-
-## Scenario 25: Product Manager Cases Must Route Into The Product Template
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package a product-manager resume with requirement design, user problem analysis, cross-team launch, KPI review, and roadmap participation.`
-
-Expected behavior:
-
-- route the case into `product management`
-- use product-specific deep-dive prompts around problem definition, priority, tradeoffs, coordination, and review
-- apply product ownership checks rather than technical or generic operations checks
-- keep the interview chain focused on product decision quality and launch review
-- avoid flattening the case into broad operations or generic project wording
-
-## Scenario 26: Personal Creation Signals Must Not Misroute Broad Operations Cases
-
-Prompt:
-
-`Today is 2026-03-29. Use $job-copilot-skill to package an operations resume that mainly targets user growth and activity operations, but includes one personal content project during a gap period.`
-
-Expected behavior:
-
-- keep broad operations as the main route
-- explain that the personal content project only borrows content-project packaging boundaries
-- require dominant content evidence or explicit content-role targeting before entering the content-operations template
-- avoid flattening the whole case into content operations just because the resume contains personal creation signals
+- route to backend with risk-control specialization
+- ask about the risk problem, strategy chain position, tradeoffs, and attack-defense iteration
+- avoid generic backend-only packaging when the risk context is the real differentiator
+- challenge high-volume or interception claims that lack denominator, time window, or ownership split
+- use risk-control pressure follow-ups instead of only generic system-design questioning


### PR DESCRIPTION
## Summary
- add segmented role pattern libraries for content operations and risk-control backend
- add role-specific pressure interview chains for those two tracks
- strengthen packaging explanation, ranking rationale, and long-dialog stage refresh rules
- extend templates, validation scenarios, and README sync for the combined upgrade

## Issues
- close #67
- close #68
- close #69
- close #70

## Validation
- run `./scripts/run_checks.sh`
- confirm `quick_validate.py` passes through the repository check script
