### PR TITLE
feat: add resume stage release gate

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -52,6 +52,34 @@ At the end of any stage that changes the user's next action, provide a short sta
 
 In long conversations, refresh this more explicitly instead of relying on implication alone.
 
+## Stage Release Gate
+
+Stage names alone are not enough. A later stage may begin only when the current stage is both complete and strong enough to support the next one.
+
+Before moving from resume packaging into mock interview or talking-point generation, the system must explicitly decide whether the resume is ready to advance.
+
+Minimum release conditions:
+
+- the target role direction is locked
+- the main story and support stories are stable enough to keep
+- at least one reviewed project version exists
+- the current version is strong enough to serve as a real interview baseline
+- major blockers are no longer at `rewrite required` level
+
+Blocked-release rule:
+
+- if the current version is still below the minimum release standard, do not advance
+- if Agent 2 outputs `rewrite required`, the release decision must be `blocked`
+- if the current version is only usable after major补充 or risk reduction, stay in the current stage and explain what still blocks release
+- the user may ask to skip ahead, but the system must still state that the stage is not released and why
+
+Required release output before stage advancement:
+
+- current rating or decision label
+- release decision: `released` or `blocked`
+- why the decision was made
+- what must be fixed before the next stage can start
+
 ## Role Routing
 
 Infer the job family before deep rewriting. Use the closest primary track, then add a secondary track only when it materially changes questions or review criteria.
@@ -130,6 +158,7 @@ For each project, Agent 2 must also produce:
 - Safer downgrade wording when needed
 - Interview pressure points
 - Ranking rationale
+- Release decision for the next stage
 
 Use [review-rubric.md](./references/review-rubric.md) for the shared review checklist.
 
@@ -163,6 +192,8 @@ Minimum fields:
 Do not allow a project into the final resume if the card is still missing basic scope, ownership, or support.
 
 Do not allow a ranked packaging plan into the final answer if it still cannot explain why that ranking is better than alternative story orders.
+
+Do not allow mock interview, self-introduction drilling, or final talking-point generation to start from a version that has not passed the release gate.
 
 ## Long-Term Memory
 
@@ -225,7 +256,7 @@ If the user says this:
 - "Rewrite my self-introduction"  
   Read resume plus memory first, then align the intro with the strongest approved project angles.
 - "Mock interview me"  
-  Use the latest reviewed wording, not raw resume text.
+  Use the latest reviewed wording, not raw resume text; if the release gate is still blocked, say so and stay in the current stage.
 - "I want stronger packaging"  
   Increase clarity and ownership only until Agent 2 can still defend it.
 - "Why is this the main project?"
@@ -259,6 +290,7 @@ Apply the skill like this:
 | Treating every project as equally important | Pick the 1 to 3 projects with the highest upside for the target role |
 | Letting Agent 1's strongest wording go straight into final output | Always run Agent 2 review first |
 | Giving a ranked packaging plan with no explanation | Explain why the main story wins on role fit, evidence, and survivability |
+| Entering mock interview before the resume is ready | Block the stage release and finish resume work first |
 | Saving every conversation detail into memory | Save only durable, reusable state |
 | Over-packaging metrics or ownership | Downgrade to the strongest version the candidate can actually defend |
 | Running mock interviews on raw or unreviewed stories | Interview only against reviewed wording |
@@ -274,6 +306,7 @@ Stop and recalibrate when any of these appear:
 - The role template changes but the review rubric does not
 - The main-story ranking changes but no one explains why
 - The conversation passes 100+ turns and the current stage is only implied
+- The user requests mock interview before the current version is strong enough to serve as the interview baseline
 - Memory starts storing unverified claims as facts
 
 When a red flag appears, ask for missing facts or downgrade the wording.

--- a/assets/project-packaging-card-template.md
+++ b/assets/project-packaging-card-template.md
@@ -96,3 +96,6 @@
 - Required supplements:
 - Downgrade wording if needed:
 - Stage blocker if not ready to advance:
+- Release decision:
+- Release rationale:
+- Minimum fixes before next stage:

--- a/docs/plans/2026-03-30-issue-82-stage-release-gate.md
+++ b/docs/plans/2026-03-30-issue-82-stage-release-gate.md
@@ -1,0 +1,50 @@
+# Issue #82 Stage Release Gate Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add explicit stage release gates so resume work cannot advance to mock interview or talking-point stages until the resume reaches a minimum release standard.
+
+**Architecture:** Tighten the main skill instructions with a release-gate section, teach the review rubric to output release decisions, and extend validation scenarios to cover blocked stage transitions. Keep the change focused on stage progression rules rather than broader rewrite heuristics.
+
+**Tech Stack:** Markdown skill docs, review rubric, validation scenarios, repository check script.
+
+### Task 1: Define the release-gate rule
+
+**Files:**
+- Modify: `SKILL.md`
+
+**Step 1:** Add a release-gate section after the stage refresh guidance.
+
+**Step 2:** Define the minimum conditions for moving from resume packaging to mock interview.
+
+**Step 3:** State that `rewrite required` or substandard resume quality blocks stage progression even if the user asks to continue.
+
+### Task 2: Extend review outputs
+
+**Files:**
+- Modify: `references/review-rubric.md`
+- Modify: `assets/project-packaging-card-template.md`
+
+**Step 1:** Add release-decision requirements to Agent 2 outputs.
+
+**Step 2:** Ensure the packaging card can record whether the candidate is ready to advance.
+
+### Task 3: Add validation coverage
+
+**Files:**
+- Modify: `references/validation-scenarios.md`
+
+**Step 1:** Add scenarios where the system must refuse to advance because the resume is still below threshold.
+
+**Step 2:** Add expectations for blocked-stage explanations and next-stage prerequisites.
+
+### Task 4: Verify and prepare PR
+
+**Files:**
+- Test: `./scripts/run_checks.sh`
+
+**Step 1:** Run `./scripts/run_checks.sh`.
+
+**Step 2:** Review diffs for issue-scope drift.
+
+**Step 3:** Commit with an issue-linked message and open a PR that closes `#82`.

--- a/references/review-rubric.md
+++ b/references/review-rubric.md
@@ -71,6 +71,17 @@ In long dialogues, check whether the current stage remains explicit enough for t
 - what is blocking the next stage
 - what condition would allow the stage to exit
 
+### 9. Stage Release Readiness
+
+Before allowing the workflow to move into mock interview, self-introduction drilling, or later-stage talking points, check whether:
+
+- the target direction is already locked
+- the main story is stable enough to keep
+- the reviewed version is strong enough to serve as an interview baseline
+- remaining problems are supplement-level rather than rewrite-level blockers
+
+If these checks fail, the release decision must be `blocked`.
+
 ## Risk Levels
 
 - `A`: safe to use now
@@ -90,3 +101,9 @@ For each project card, output:
 - likely interview pressure points
 - ranking rationale
 - stage blocker if the dialogue has not advanced
+
+For each resume-stage conclusion, also output:
+
+- release decision: `released` or `blocked`
+- release rationale
+- minimum fixes required before the next stage

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -107,3 +107,30 @@ Expected behavior:
 - avoid generic backend-only packaging when the risk context is the real differentiator
 - challenge high-volume or interception claims that lack denominator, time window, or ownership split
 - use risk-control pressure follow-ups instead of only generic system-design questioning
+
+## Scenario 8: Block Mock Interview Until Resume Is Ready
+
+Prompt:
+
+`Use $job-copilot-skill to mock interview me now. I know my resume still has unclear metrics, unstable main stories, and several rewrite-required sections, but I want to practice first.`
+
+Expected behavior:
+
+- refuse to release the workflow into mock interview
+- state that the release decision is blocked
+- explain why the current version is not strong enough to serve as the interview baseline
+- list the minimum fixes needed before mock interview can start
+- stay in the current resume stage instead of partially doing the next stage
+
+## Scenario 9: Release Only After Resume Passes Threshold
+
+Prompt:
+
+`Use $job-copilot-skill to continue from our finished resume rewrite and start mock interview drills. We already locked the target role, finalized the main story, and passed review with only small supplement notes left.`
+
+Expected behavior:
+
+- confirm that the release gate is now satisfied
+- state that the release decision is released
+- briefly name the remaining supplement notes without blocking progression
+- move into mock interview only after making the release decision explicit


### PR DESCRIPTION
## Summary
- add an explicit stage release gate before resume work can advance into mock interview
- extend review outputs and packaging cards with released/blocked decisions
- add validation scenarios for blocked and released stage transitions

## Issue
- close #82

## Validation
- run `./scripts/run_checks.sh`
