### PR TITLE
feat: require value-driven resume rewrites

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -11,8 +11,6 @@ Run internet job-search coaching as a controlled system, not as one-off copy edi
 
 The core pattern is `Agent 1 writes, Agent 2 reviews`. Agent 1 pulls signal out of weak or incomplete material; Agent 2 challenges unsupported claims, over-packaging, and role mismatch. Keep a running `memory.md` so future sessions resume from the candidate's actual state.
 
-The system must also explain itself. It is not enough to output a stronger package. The user should be able to understand why a project became the main story, why another project stayed secondary, why a gap-period item was downgraded, and what would be needed to advance to the next stage.
-
 ## When to Use
 
 Use this skill when the user wants any of the following:
@@ -43,43 +41,6 @@ Follow this sequence every time. Do not skip directly to rewritten bullets unles
 | `6. Train` | Run mock interviews against the reviewed version | Interview notes, error log, next drills |
 | `7. Persist` | Update long-term memory with confirmed facts and recurring gaps | `memory.md` |
 
-At the end of any stage that changes the user's next action, provide a short stage refresh containing:
-
-- current stage
-- why the process is still in that stage
-- blocker or missing support
-- condition to exit the stage
-
-In long conversations, refresh this more explicitly instead of relying on implication alone.
-
-## Stage Release Gate
-
-Stage names alone are not enough. A later stage may begin only when the current stage is both complete and strong enough to support the next one.
-
-Before moving from resume packaging into mock interview or talking-point generation, the system must explicitly decide whether the resume is ready to advance.
-
-Minimum release conditions:
-
-- the target role direction is locked
-- the main story and support stories are stable enough to keep
-- at least one reviewed project version exists
-- the current version is strong enough to serve as a real interview baseline
-- major blockers are no longer at `rewrite required` level
-
-Blocked-release rule:
-
-- if the current version is still below the minimum release standard, do not advance
-- if Agent 2 outputs `rewrite required`, the release decision must be `blocked`
-- if the current version is only usable after major补充 or risk reduction, stay in the current stage and explain what still blocks release
-- the user may ask to skip ahead, but the system must still state that the stage is not released and why
-
-Required release output before stage advancement:
-
-- current rating or decision label
-- release decision: `released` or `blocked`
-- why the decision was made
-- what must be fixed before the next stage can start
-
 ## Role Routing
 
 Infer the job family before deep rewriting. Use the closest primary track, then add a secondary track only when it materially changes questions or review criteria.
@@ -99,11 +60,6 @@ Supported template families:
 
 Use the routing and evaluation guidance in [job-families.md](./references/job-families.md).
 
-When the selected family has a segmented-role reference, apply that reference in addition to the shared family guidance. Current segmented references:
-
-- `operations` -> [content-operations-patterns.md](./references/content-operations-patterns.md)
-- `backend` in risk-control / anti-crawler contexts -> [risk-control-backend-patterns.md](./references/risk-control-backend-patterns.md)
-
 ## Dual-Agent Contract
 
 Treat the system as two distinct passes, even if the environment only has one visible assistant.
@@ -117,7 +73,6 @@ Responsibilities:
 - Ask for business context, scope, actions, constraints, tradeoffs, metrics, and lessons
 - Build a candidate project packaging card before writing final bullets
 - Produce stronger resume wording, self-introduction drafts, and interview-ready storylines
-- Explain why each chosen story is ranked as main, support, or gap-explanation material
 
 Agent 1 is allowed to:
 
@@ -125,14 +80,24 @@ Agent 1 is allowed to:
 - Reorder facts to emphasize impact
 - Convert vague participation into precise contribution language when the candidate can explain it
 - Suggest missing support details that must be confirmed
-- Use segmented-role pattern references when they materially change what "strong" looks like
+
+When rewriting experience sections, Agent 1 must use value-driven rather than duty-driven structure.
+
+Rewrite rules:
+
+- keep each experience to the 3 to 5 strongest bullets unless the user explicitly asks for a fuller version
+- make the first bullet the strongest proof of role fit or business value
+- avoid giving equal weight to every work module
+- aim for `scene or problem -> action or method -> result or value`
+- if a hard metric is unsafe, still preserve the value by describing the solved problem, improved workflow, supported decision, or lowered risk
+- do not flatten strong systems, data, reporting, policy, or process work into generic execution language just to shorten the section
 
 Agent 1 is not allowed to:
 
 - Invent projects, ownership, metrics, or tech the candidate cannot defend
 - Treat team outcomes as personal outcomes without attribution
 - Hide uncertainty; mark unconfirmed items as gaps
-- Output a stronger ranking without explaining the reason for that ranking
+- return a JD-aligned rewrite that still reads like a work checklist
 
 ### Agent 2: Review And Calibrate
 
@@ -143,7 +108,7 @@ Responsibilities:
 - Judge role-template fit: does this read like a real candidate for the routed job family?
 - Identify interview failure points: what breaks under 3 to 5 follow-up questions?
 - Force a downgrade when the candidate cannot support a stronger version
-- Challenge ranking logic and explanation quality, not just wording quality
+- Challenge rewrites that match keywords but still read like duties instead of candidate value
 
 Agent 2 outputs:
 
@@ -157,15 +122,9 @@ For each project, Agent 2 must also produce:
 - Risk notes
 - Safer downgrade wording when needed
 - Interview pressure points
-- Ranking rationale
-- Release decision for the next stage
+- Strongest value proof
 
 Use [review-rubric.md](./references/review-rubric.md) for the shared review checklist.
-
-When the routed case matches a segmented role, Agent 2 should also use the relevant segmented reference:
-
-- [content-operations-patterns.md](./references/content-operations-patterns.md)
-- [risk-control-backend-patterns.md](./references/risk-control-backend-patterns.md)
 
 ## Project Packaging Card
 
@@ -183,17 +142,20 @@ Minimum fields:
 - Main challenge and solution
 - Result or value
 - Packaging goal
-- Packaging explanation layer
 - Missing support
 - Risk notes
 - Resume-ready wording
 - Interview-ready explanation
 
+For experience rewriting, also capture:
+
+- strongest role value
+- whether the draft still reads like duty inventory
+- what should be cut before the section becomes strongest-first
+
 Do not allow a project into the final resume if the card is still missing basic scope, ownership, or support.
 
-Do not allow a ranked packaging plan into the final answer if it still cannot explain why that ranking is better than alternative story orders.
-
-Do not allow mock interview, self-introduction drilling, or final talking-point generation to start from a version that has not passed the release gate.
+Do not allow an experience rewrite into the final resume if it still reads like an equal-weight task list rather than a strongest-first value summary.
 
 ## Long-Term Memory
 
@@ -203,7 +165,6 @@ The memory file should track:
 
 - Candidate profile and job-search targets
 - Current approved resume direction
-- Approved ranking logic and current stage blockers
 - Project archive with statuses
 - Approved resume wording and self-introduction
 - Review risks and banned phrasing
@@ -236,16 +197,10 @@ For every weak answer, record:
 
 - The question
 - What failed
-- Which pressure chain exposed the failure
 - Better answer structure
 - What to study or clarify next
 
 Log these in [interview-error-log-template.md](./assets/interview-error-log-template.md).
-
-When available, use segmented pressure chains instead of generic follow-up logic:
-
-- [content-operations-interview-chain.md](./references/content-operations-interview-chain.md)
-- [risk-control-backend-interview-chain.md](./references/risk-control-backend-interview-chain.md)
 
 ## Quick Reference
 
@@ -256,15 +211,13 @@ If the user says this:
 - "Rewrite my self-introduction"  
   Read resume plus memory first, then align the intro with the strongest approved project angles.
 - "Mock interview me"  
-  Use the latest reviewed wording, not raw resume text; if the release gate is still blocked, say so and stay in the current stage.
+  Use the latest reviewed wording, not raw resume text.
 - "I want stronger packaging"  
   Increase clarity and ownership only until Agent 2 can still defend it.
-- "Why is this the main project?"
-  Explain the ranking using role relevance, evidence strength, time recency, and interview survivability.
+- "This still reads like job duties"
+  Rebuild each experience into strongest-first scene, action, and value bullets.
 - "I don't want to repeat myself next session"  
   Read and update `memory.md`.
-- "Why are we still here?"
-  Refresh the current stage, blocker, and exit condition before continuing.
 
 ## Example
 
@@ -277,10 +230,11 @@ Apply the skill like this:
 1. Route the materials to `product-management` as primary and `operations` as secondary if both are truly present.
 2. Ask Agent 1 questions that expose business goals, user problems, actions taken, cross-team coordination, and measurable results.
 3. Fill a project packaging card for the strongest project.
-4. Explain why that project should be the main story instead of another candidate project.
-5. Run Agent 2 review to check inflated ownership, missing metrics, weak strategic logic, and whether the ranking rationale holds up.
+4. Rewrite the strongest experience into a 3 to 5 bullet section that leads with the clearest value proof.
+5. Run Agent 2 review to check inflated ownership, missing metrics, weak strategic logic, and whether the rewrite still sounds like duties instead of value.
 6. Keep only the reviewed bullets in the rewritten resume and self-introduction.
-7. Add a short stage refresh and update `memory.md` with approved wording, weak points, next drills, and current blocker if any.
+7. Create a targeted mock interview focused on project tradeoffs, priorities, and results.
+8. Update `memory.md` with approved wording, weak points, and next drills.
 
 ## Common Mistakes
 
@@ -289,8 +243,7 @@ Apply the skill like this:
 | Rewriting the whole resume before clarifying the role | Route the candidate first, then choose the correct template family |
 | Treating every project as equally important | Pick the 1 to 3 projects with the highest upside for the target role |
 | Letting Agent 1's strongest wording go straight into final output | Always run Agent 2 review first |
-| Giving a ranked packaging plan with no explanation | Explain why the main story wins on role fit, evidence, and survivability |
-| Entering mock interview before the resume is ready | Block the stage release and finish resume work first |
+| Matching the JD but still sounding like a task list | Rebuild the section around strongest-first value bullets |
 | Saving every conversation detail into memory | Save only durable, reusable state |
 | Over-packaging metrics or ownership | Downgrade to the strongest version the candidate can actually defend |
 | Running mock interviews on raw or unreviewed stories | Interview only against reviewed wording |
@@ -303,10 +256,8 @@ Stop and recalibrate when any of these appear:
 - "Just write something impressive"
 - A metric appears with no source or explanation
 - Ownership grows while the candidate's explanation shrinks
+- Every bullet starts with a duty verb and none show why the work mattered
 - The role template changes but the review rubric does not
-- The main-story ranking changes but no one explains why
-- The conversation passes 100+ turns and the current stage is only implied
-- The user requests mock interview before the current version is strong enough to serve as the interview baseline
 - Memory starts storing unverified claims as facts
 
 When a red flag appears, ask for missing facts or downgrade the wording.

--- a/assets/project-packaging-card-template.md
+++ b/assets/project-packaging-card-template.md
@@ -52,8 +52,7 @@
 ## Packaging Goal
 
 - What capability this project should signal:
-- Why this should be a main story, support story, or gap explanation:
-- Why this ordering is better than competing stories:
+- Strongest role value:
 
 ## Missing Support
 
@@ -71,13 +70,7 @@
 
 - Bullet 1:
 - Bullet 2:
-
-## Packaging Explanation Layer
-
-- Role-fit explanation:
-- Ranking rationale:
-- Evidence ceiling:
-- Why stronger wording would become unsafe:
+- Does this still read like duty inventory:
 
 ## Interview-Ready Story
 
@@ -86,7 +79,6 @@
 - Challenge:
 - Solution:
 - Result:
-- Likely pressure follow-up chain:
 
 ## Review Output
 
@@ -95,7 +87,5 @@
 - Top review concerns:
 - Required supplements:
 - Downgrade wording if needed:
-- Stage blocker if not ready to advance:
-- Release decision:
-- Release rationale:
-- Minimum fixes before next stage:
+- Strongest value proof:
+- Still reads like duty list:

--- a/docs/plans/2026-03-30-issue-79-value-driven-rewrite.md
+++ b/docs/plans/2026-03-30-issue-79-value-driven-rewrite.md
@@ -1,0 +1,50 @@
+# Issue #79 Value-Driven Rewrite Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent JD-focused resume rewrites from collapsing into duty lists by requiring value-driven experience bullets.
+
+**Architecture:** Tighten the main skill with explicit rewrite structure rules, extend the review rubric to judge value-density and bullet quality, and add validation scenarios that fail when a rewrite still reads like a task list.
+
+**Tech Stack:** Markdown skill docs, review rubric, validation scenarios, repository check script.
+
+### Task 1: Add rewrite structure rules
+
+**Files:**
+- Modify: `SKILL.md`
+
+**Step 1:** Add explicit rules for experience bullets to prioritize value over task inventory.
+
+**Step 2:** Require 3-5 strongest bullets per experience instead of equal-weight module dumping.
+
+**Step 3:** Require the first bullet to capture the strongest role value.
+
+### Task 2: Extend review rubric
+
+**Files:**
+- Modify: `references/review-rubric.md`
+- Modify: `assets/project-packaging-card-template.md`
+
+**Step 1:** Add a check for value-driven rather than duty-driven experience writing.
+
+**Step 2:** Ensure project cards capture the strongest value proof and candidate-facing scene/action/value logic.
+
+### Task 3: Add validation coverage
+
+**Files:**
+- Modify: `references/validation-scenarios.md`
+
+**Step 1:** Add scenarios where the rewrite matches the JD but still reads like a task list.
+
+**Step 2:** Add expectations for bullet pruning, strongest-first ordering, and value framing.
+
+### Task 4: Verify and prepare PR
+
+**Files:**
+- Test: `./scripts/run_checks.sh`
+
+**Step 1:** Run `./scripts/run_checks.sh`.
+
+**Step 2:** Review diffs for issue-scope drift.
+
+**Step 3:** Commit with an issue-linked message and open a PR that closes `#79`.

--- a/references/review-rubric.md
+++ b/references/review-rubric.md
@@ -41,8 +41,6 @@ Reject wording the candidate probably cannot explain under follow-up:
 
 Check whether the project now sounds like a real candidate for the routed job family.
 
-If a segmented role reference exists for the routed case, check whether the wording also sounds like a real candidate for that sub-direction rather than a generic family member.
-
 ### 5. Result Credibility
 
 Challenge:
@@ -55,32 +53,16 @@ Challenge:
 
 Ask whether the story can survive 3 to 5 follow-up questions. If not, downgrade or request more support.
 
-### 7. Packaging Explanation Quality
+### 7. Value Density
 
-Check whether the packaging coach can explain:
+Check whether the rewrite reads like a candidate value summary rather than a duty list.
 
-- why this project is ranked as main story, support story, or gap explanation
-- why the chosen wording ceiling matches the available evidence
-- why this packaging is a better fit for the routed role than alternative stories
+Challenge rewrites where:
 
-### 8. Long-Conversation Stage Legibility
-
-In long dialogues, check whether the current stage remains explicit enough for the user to understand:
-
-- why the process is still in this stage
-- what is blocking the next stage
-- what condition would allow the stage to exit
-
-### 9. Stage Release Readiness
-
-Before allowing the workflow to move into mock interview, self-introduction drilling, or later-stage talking points, check whether:
-
-- the target direction is already locked
-- the main story is stable enough to keep
-- the reviewed version is strong enough to serve as an interview baseline
-- remaining problems are supplement-level rather than rewrite-level blockers
-
-If these checks fail, the release decision must be `blocked`.
+- every bullet has equal weight and no strongest proof appears first
+- the section matches JD keywords but still sounds like checklist work
+- systems, data, reporting, policy, or process work are reduced to low-value admin wording
+- the rewrite says what happened but not why it mattered
 
 ## Risk Levels
 
@@ -99,11 +81,5 @@ For each project card, output:
 - missing info to collect
 - downgrade wording if needed
 - likely interview pressure points
-- ranking rationale
-- stage blocker if the dialogue has not advanced
-
-For each resume-stage conclusion, also output:
-
-- release decision: `released` or `blocked`
-- release rationale
-- minimum fixes required before the next stage
+- strongest value proof
+- whether the section still reads like a duty list

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -52,85 +52,28 @@ Expected behavior:
 - focus on stored weak points and error log
 - update memory after the mock interview
 
-## Scenario 4: Packaging Explanation And Ranking
+## Scenario 4: JD Match But Still Reads Like Duties
 
 Prompt:
 
-`Use $job-copilot-skill to improve my resume for product roles. I have three projects and I want to know why one should be my main story and the others should be secondary.`
+`Use $job-copilot-skill to rewrite my resume for a Global SSC / HR Ops JD. The keywords are all there now, but it still reads like I just listed responsibilities.`
 
 Expected behavior:
 
-- route to product management
-- select one main story and explain why
-- explain why the other projects are support stories instead of main stories
-- reference role relevance, time recency, result strength, explainability, or risk boundary
-- avoid outputting a ranking with no justification
+- rebuild the experience section into strongest-first value bullets
+- keep only the highest-value 3 to 5 bullets per experience instead of equal-weight module dumping
+- explain why the first bullet is the strongest proof of role fit
+- preserve systems, data, reporting, policy, or process value instead of deleting them as low-value admin work
 
-## Scenario 5: Long Dialogue Stage Refresh
+## Scenario 5: Strong Lines Must Survive Compression
 
 Prompt:
 
-`Use $job-copilot-skill to continue our long resume rewrite. We have already talked for a long time and I am not sure why we are still here.`
+`Use $job-copilot-skill to shorten my SSC resume to 4 / 3 / 3 bullets, but do not lose the HRIS, FAQ, reporting, and process-efficiency parts that make me stronger.`
 
 Expected behavior:
 
-- restate the current stage explicitly
-- explain why the process is still in that stage
-- name the blocker or missing information
-- state the condition required to move to the next stage
-- keep the refresh concise rather than turning it into a full report
-
-## Scenario 6: Content Operations And Self-Media Specialization
-
-Prompt:
-
-`Use $job-copilot-skill to help me target content operations roles. I have formal operations experience plus a year of running my own content account during a gap.`
-
-Expected behavior:
-
-- route to operations with content-operations specialization
-- separate formal role experience from personal content or gap-period material
-- explain whether the personal content period is a main story, support story, or gap explanation
-- challenge metrics that lack baseline, period, or attribution
-- use content-operations-style follow-up questions instead of generic operations questions
-
-## Scenario 7: Risk-Control Backend Specialization
-
-Prompt:
-
-`Use $job-copilot-skill to improve my resume for risk-control backend roles. My background includes anti-crawler strategy services and device recognition work.`
-
-Expected behavior:
-
-- route to backend with risk-control specialization
-- ask about the risk problem, strategy chain position, tradeoffs, and attack-defense iteration
-- avoid generic backend-only packaging when the risk context is the real differentiator
-- challenge high-volume or interception claims that lack denominator, time window, or ownership split
-- use risk-control pressure follow-ups instead of only generic system-design questioning
-
-## Scenario 8: Block Mock Interview Until Resume Is Ready
-
-Prompt:
-
-`Use $job-copilot-skill to mock interview me now. I know my resume still has unclear metrics, unstable main stories, and several rewrite-required sections, but I want to practice first.`
-
-Expected behavior:
-
-- refuse to release the workflow into mock interview
-- state that the release decision is blocked
-- explain why the current version is not strong enough to serve as the interview baseline
-- list the minimum fixes needed before mock interview can start
-- stay in the current resume stage instead of partially doing the next stage
-
-## Scenario 9: Release Only After Resume Passes Threshold
-
-Prompt:
-
-`Use $job-copilot-skill to continue from our finished resume rewrite and start mock interview drills. We already locked the target role, finalized the main story, and passed review with only small supplement notes left.`
-
-Expected behavior:
-
-- confirm that the release gate is now satisfied
-- state that the release decision is released
-- briefly name the remaining supplement notes without blocking progression
-- move into mock interview only after making the release decision explicit
+- obey the shorter structure without mechanically deleting high-value lines
+- keep the strongest systems, data, reporting, or process-improvement proof if those are core to the target role
+- explain what was cut and why it was lower value than the retained bullets
+- avoid turning the candidate into a generic transaction-only executor


### PR DESCRIPTION
## Summary
- require experience rewrites to lead with strongest value rather than task inventory
- extend review outputs and packaging cards with strongest-value and duty-list checks
- add validation scenarios for JD-aligned but still checklist-style rewrites

## Issue
- close #79

## Validation
- run `./scripts/run_checks.sh`
