### PR TITLE
feat: add excellent resume baseline workflow

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -41,6 +41,7 @@ Follow this sequence every time. Do not skip directly to rewritten bullets unles
 | `6. Train` | Run mock interviews against the reviewed version | Interview notes, error log, next drills |
 | `7. Persist` | Update long-term memory with confirmed facts and recurring gaps | `memory.md` |
 
+If the user asks for a stronger target version, an excellent sample, or "what a good resume should look like", do not jump straight into local edits. Define the excellent baseline first, then compare the current resume against it, then rewrite.
 ## Role Routing
 
 Infer the job family before deep rewriting. Use the closest primary track, then add a secondary track only when it materially changes questions or review criteria.
@@ -60,6 +61,7 @@ Supported template families:
 
 Use the routing and evaluation guidance in [job-families.md](./references/job-families.md).
 
+When the user asks for an excellent target version or a stronger comparison baseline, also use [excellent-resume-baseline.md](./references/excellent-resume-baseline.md).
 ## Dual-Agent Contract
 
 Treat the system as two distinct passes, even if the environment only has one visible assistant.
@@ -91,6 +93,7 @@ Rewrite rules:
 - aim for `scene or problem -> action or method -> result or value`
 - if a hard metric is unsafe, still preserve the value by describing the solved problem, improved workflow, supported decision, or lowered risk
 - do not flatten strong systems, data, reporting, policy, or process work into generic execution language just to shorten the section
+- define a routed-role excellent baseline before rewriting when the user explicitly asks for it
 
 Agent 1 is not allowed to:
 
@@ -98,6 +101,7 @@ Agent 1 is not allowed to:
 - Treat team outcomes as personal outcomes without attribution
 - Hide uncertainty; mark unconfirmed items as gaps
 - return a JD-aligned rewrite that still reads like a work checklist
+- rewrite directly against the user's current draft when the user first asked to see the stronger target version
 
 ### Agent 2: Review And Calibrate
 
@@ -123,6 +127,13 @@ For each project, Agent 2 must also produce:
 - Safer downgrade wording when needed
 - Interview pressure points
 - Strongest value proof
+- Ranking rationale
+
+For each resume-stage conclusion, Agent 2 must also produce:
+
+- Release decision: `released` or `blocked`
+- Release rationale
+- Minimum fixes required before the next stage
 
 Use [review-rubric.md](./references/review-rubric.md) for the shared review checklist.
 
@@ -154,9 +165,7 @@ For experience rewriting, also capture:
 - what should be cut before the section becomes strongest-first
 
 Do not allow a project into the final resume if the card is still missing basic scope, ownership, or support.
-
 Do not allow an experience rewrite into the final resume if it still reads like an equal-weight task list rather than a strongest-first value summary.
-
 ## Long-Term Memory
 
 Maintain a running `memory.md` for the candidate. Read it before starting work and update it after any meaningful milestone.
@@ -216,6 +225,8 @@ If the user says this:
   Increase clarity and ownership only until Agent 2 can still defend it.
 - "This still reads like job duties"
   Rebuild each experience into strongest-first scene, action, and value bullets.
+- "Show me what a strong version should look like first"
+  Present the excellent baseline, then analyze the gap, then decide what to rewrite.
 - "I don't want to repeat myself next session"  
   Read and update `memory.md`.
 
@@ -241,6 +252,7 @@ Apply the skill like this:
 | Mistake | Correction |
 |---|---|
 | Rewriting the whole resume before clarifying the role | Route the candidate first, then choose the correct template family |
+| Rewriting before defining the target shape | Show the excellent baseline first when the user asks for it |
 | Treating every project as equally important | Pick the 1 to 3 projects with the highest upside for the target role |
 | Letting Agent 1's strongest wording go straight into final output | Always run Agent 2 review first |
 | Matching the JD but still sounding like a task list | Rebuild the section around strongest-first value bullets |
@@ -257,6 +269,7 @@ Stop and recalibrate when any of these appear:
 - A metric appears with no source or explanation
 - Ownership grows while the candidate's explanation shrinks
 - Every bullet starts with a duty verb and none show why the work mattered
+- The user asked for an excellent sample, but the response skipped straight to editing the current draft
 - The role template changes but the review rubric does not
 - Memory starts storing unverified claims as facts
 

--- a/docs/plans/2026-03-30-issue-81-excellent-baseline.md
+++ b/docs/plans/2026-03-30-issue-81-excellent-baseline.md
@@ -1,0 +1,47 @@
+# Issue #81 Excellent Resume Baseline Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a baseline-first workflow so the system can show what an excellent target resume should look like before rewriting the current draft.
+
+**Architecture:** Introduce a reusable baseline reference, wire it into the main skill, and add validation scenarios for baseline-first and realistic-upper-bound behavior.
+
+**Tech Stack:** Markdown skill docs, reference files, validation scenarios, repository check script.
+
+### Task 1: Add baseline reference
+
+**Files:**
+- Create: `references/excellent-resume-baseline.md`
+
+**Step 1:** Define what the excellent baseline is and is not.
+
+**Step 2:** Document required structure for baseline-first analysis.
+
+### Task 2: Wire baseline-first flow into the skill
+
+**Files:**
+- Modify: `SKILL.md`
+
+**Step 1:** Add a rule that baseline-first analysis should happen when the user explicitly asks for the stronger target version.
+
+**Step 2:** Add quick-reference and mistake guidance so the baseline is not skipped.
+
+### Task 3: Add validation coverage
+
+**Files:**
+- Modify: `references/validation-scenarios.md`
+
+**Step 1:** Add a scenario where the user asks for an excellent sample before edits.
+
+**Step 2:** Add a scenario where the baseline must stay realistic to the candidate's actual background.
+
+### Task 4: Verify and prepare PR
+
+**Files:**
+- Test: `./scripts/run_checks.sh`
+
+**Step 1:** Run `./scripts/run_checks.sh`.
+
+**Step 2:** Review diffs for issue-scope drift.
+
+**Step 3:** Commit with an issue-linked message and open a PR that closes `#81`.

--- a/references/excellent-resume-baseline.md
+++ b/references/excellent-resume-baseline.md
@@ -1,0 +1,54 @@
+# Excellent Resume Baseline
+
+Use this file when the user wants to know what a strong target resume should look like before rewriting their current version.
+
+## Purpose
+
+Do not start from local edits alone when the user explicitly asks for a stronger target shape. First define the baseline the candidate should move toward.
+
+The baseline is not a copyable template. It is a target candidate image for the routed job family.
+
+## What The Baseline Must Include
+
+For the routed role, show:
+
+- target title or positioning line
+- a short summary that explains why this candidate is worth interviewing
+- the strongest 1 to 2 career themes
+- how the main project should look
+- how support projects should be positioned
+- what should be weak, removed, or downgraded
+
+## Output Structure
+
+When the user asks for an excellent sample or a stronger target version, answer in this order:
+
+1. What a strong candidate in this route usually looks like
+2. A sample baseline resume or candidate image
+3. A gap analysis against the user's current resume
+4. What to strengthen now versus what can only be downgraded safely
+
+## Baseline Rules
+
+- Keep the baseline in the user's real direction; do not invent a different candidate
+- Do not rely on generic polished bullets alone
+- Show what gets emphasis and what loses weight
+- Make the main story obvious
+- If the user's background cannot honestly reach the strongest market version, say what upper bound is realistic
+
+## Gap Analysis Questions
+
+Use these questions after presenting the baseline:
+
+- What does the strong version signal in the first screen that the current resume does not?
+- Which project should become the main story?
+- Which experience currently steals space without helping conversion?
+- Which claims are too weak to reach the baseline and therefore need downgrade rather than upgrade?
+- What missing support prevents the current resume from reaching the target version?
+
+## Common Failure Modes
+
+- rewriting the current resume without first defining the target shape
+- using a template page as if it were the actual baseline
+- giving abstract advice without a concrete candidate image
+- presenting an impossible target version the user cannot defend

--- a/references/validation-scenarios.md
+++ b/references/validation-scenarios.md
@@ -52,7 +52,32 @@ Expected behavior:
 - focus on stored weak points and error log
 - update memory after the mock interview
 
-## Scenario 4: JD Match But Still Reads Like Duties
+## Scenario 4: Ask For Excellent Baseline Before Rewrite
+
+Prompt:
+
+`Use $job-copilot-skill to show me what an excellent resume for content operations should look like first, then tell me how far my current resume is from that version.`
+
+Expected behavior:
+
+- define the target excellent baseline before rewriting the current draft
+- show the strongest candidate image for the routed role
+- explain the gap between the current resume and the baseline
+- distinguish what can be strengthened from what can only be downgraded safely
+
+## Scenario 5: Baseline Must Be Realistic
+
+Prompt:
+
+`Use $job-copilot-skill to show me the strongest version of my resume, but keep it honest to my real background.`
+
+Expected behavior:
+
+- provide a stronger target shape without inventing a different candidate
+- state where the realistic upper bound is lower than the market-best version
+- avoid turning the baseline into unsupported senior language
+
+## Scenario 6: JD Match But Still Reads Like Duties
 
 Prompt:
 
@@ -65,7 +90,7 @@ Expected behavior:
 - explain why the first bullet is the strongest proof of role fit
 - preserve systems, data, reporting, policy, or process value instead of deleting them as low-value admin work
 
-## Scenario 5: Strong Lines Must Survive Compression
+## Scenario 7: Strong Lines Must Survive Compression
 
 Prompt:
 


### PR DESCRIPTION
## Summary
- add a reusable excellent-resume baseline reference
- require baseline-first analysis when the user asks for the stronger target version
- add validation scenarios for baseline-first and realistic-upper-bound behavior

## Issue
- close #81

## Validation
- run `./scripts/run_checks.sh`
